### PR TITLE
109 match pantheon varnish max header

### DIFF
--- a/examples/drupal7/README.md
+++ b/examples/drupal7/README.md
@@ -131,7 +131,8 @@ cd drupal7
 lando ssh -s appserver -c "curl https://index:449/sites/self/environments/lando/index/admin/"
 
 # Should use a varnish http_resp_hdr_len setting of 25k
-lando varnishadm param.show http_resp_hdr_len 2>&1 | grep 'Value is: 25k'
+cd drupal7
+lando varnishadm param.show http_resp_hdr_len | grep 'Value is: 25k'
 
 # Should be able to push commits to pantheon
 cd drupal7

--- a/examples/drupal7/README.md
+++ b/examples/drupal7/README.md
@@ -130,6 +130,9 @@ lando ssh -s appserver_nginx -c "/opt/bitnami/nginx/sbin/nginx -v 2>&1 | grep 1.
 cd drupal7
 lando ssh -s appserver -c "curl https://index:449/sites/self/environments/lando/index/admin/"
 
+# Should use a varnish http_resp_hdr_len setting of 25k
+lando varnishadm param.show http_resp_hdr_len | grep 'Value is: 25k'
+
 # Should be able to push commits to pantheon
 cd drupal7
 lando pull --code dev --database none --files none

--- a/examples/drupal7/README.md
+++ b/examples/drupal7/README.md
@@ -131,7 +131,7 @@ cd drupal7
 lando ssh -s appserver -c "curl https://index:449/sites/self/environments/lando/index/admin/"
 
 # Should use a varnish http_resp_hdr_len setting of 25k
-lando varnishadm param.show http_resp_hdr_len | grep 'Value is: 25k'
+lando varnishadm param.show http_resp_hdr_len 2>&1 | grep 'Value is: 25k'
 
 # Should be able to push commits to pantheon
 cd drupal7

--- a/examples/drupal8/README.md
+++ b/examples/drupal8/README.md
@@ -96,7 +96,8 @@ cd drupal8
 lando php -v | grep "PHP 7.4"
 
 # Should use a varnish http_resp_hdr_len setting of 25k
-lando varnishadm param.show http_resp_hdr_len 2>&1 | grep 'Value is: 25k'
+cd drupal8
+lando varnishadm param.show http_resp_hdr_len | grep 'Value is: 25k'
 
 # Should have all pantheon services running and their tooling enabled by defaults
 docker ps --filter label=com.docker.compose.project=landobotdrupal8 | grep landobotdrupal8_appserver_nginx_1

--- a/examples/drupal8/README.md
+++ b/examples/drupal8/README.md
@@ -95,6 +95,9 @@ lando ssh -c "env" | grep TERMINUS_USER | grep droid@lando.dev
 cd drupal8
 lando php -v | grep "PHP 7.4"
 
+# Should use a varnish http_resp_hdr_len setting of 25k
+lando varnishadm param.show http_resp_hdr_len | grep 'Value is: 25k'
+
 # Should have all pantheon services running and their tooling enabled by defaults
 docker ps --filter label=com.docker.compose.project=landobotdrupal8 | grep landobotdrupal8_appserver_nginx_1
 docker ps --filter label=com.docker.compose.project=landobotdrupal8 | grep landobotdrupal8_appserver_1

--- a/examples/drupal8/README.md
+++ b/examples/drupal8/README.md
@@ -96,7 +96,7 @@ cd drupal8
 lando php -v | grep "PHP 7.4"
 
 # Should use a varnish http_resp_hdr_len setting of 25k
-lando varnishadm param.show http_resp_hdr_len | grep 'Value is: 25k'
+lando varnishadm param.show http_resp_hdr_len 2>&1 | grep 'Value is: 25k'
 
 # Should have all pantheon services running and their tooling enabled by defaults
 docker ps --filter label=com.docker.compose.project=landobotdrupal8 | grep landobotdrupal8_appserver_nginx_1

--- a/examples/drupal9/README.md
+++ b/examples/drupal9/README.md
@@ -84,7 +84,7 @@ cd drupal9
 lando php -v | grep "PHP 8.0"
 
 # Should use a varnish http_resp_hdr_len setting of 25k
-lando varnishadm param.show http_resp_hdr_len | grep 'Value is: 25k'
+lando varnishadm param.show http_resp_hdr_len 2>&1 | grep 'Value is: 25k'
 
 # Should have all pantheon services running and their tooling enabled by defaults
 docker ps --filter label=com.docker.compose.project=landobotdrupal9 | grep landobotdrupal9_appserver_nginx_1

--- a/examples/drupal9/README.md
+++ b/examples/drupal9/README.md
@@ -84,7 +84,8 @@ cd drupal9
 lando php -v | grep "PHP 8.0"
 
 # Should use a varnish http_resp_hdr_len setting of 25k
-lando varnishadm param.show http_resp_hdr_len 2>&1 | grep 'Value is: 25k'
+cd drupal9
+lando varnishadm param.show http_resp_hdr_len | grep 'Value is: 25k'
 
 # Should have all pantheon services running and their tooling enabled by defaults
 docker ps --filter label=com.docker.compose.project=landobotdrupal9 | grep landobotdrupal9_appserver_nginx_1

--- a/examples/drupal9/README.md
+++ b/examples/drupal9/README.md
@@ -83,6 +83,9 @@ lando ssh -c "env" | grep TERMINUS_USER | grep droid@lando.dev
 cd drupal9
 lando php -v | grep "PHP 8.0"
 
+# Should use a varnish http_resp_hdr_len setting of 25k
+lando varnishadm param.show http_resp_hdr_len | grep 'Value is: 25k'
+
 # Should have all pantheon services running and their tooling enabled by defaults
 docker ps --filter label=com.docker.compose.project=landobotdrupal9 | grep landobotdrupal9_appserver_nginx_1
 docker ps --filter label=com.docker.compose.project=landobotdrupal9 | grep landobotdrupal9_appserver_1

--- a/examples/init/README.md
+++ b/examples/init/README.md
@@ -86,7 +86,8 @@ cd drupal9
 lando php -v | grep "PHP 8.0"
 
 # Should use a varnish http_resp_hdr_len setting of 25k
-lando varnishadm param.show http_resp_hdr_len 2>&1 | grep 'Value is: 25k'
+cd drupal9
+lando varnishadm param.show http_resp_hdr_len | grep 'Value is: 25k'
 
 # Should have all pantheon services running and their tooling enabled by defaults
 docker ps --filter label=com.docker.compose.project=landobotdrupal9 | grep landobotdrupal9_appserver_nginx_1

--- a/examples/init/README.md
+++ b/examples/init/README.md
@@ -80,7 +80,6 @@ lando ssh -c "env" | grep PRESSFLOW_SETTINGS | grep pantheon
 lando ssh -c "env" | grep TERMINUS_ENV | grep dev
 lando ssh -c "env" | grep TERMINUS_SITE | grep landobot-drupal9
 lando ssh -c "env" | grep TERMINUS_USER | grep droid@lando.dev
-lando ssh -c "env" | grep PANTHEON_EDGE_HTTP_RESP_HDR_LEN | grep '25k'
 
 # Should use php version in pantheon.upstream.yml
 cd drupal9

--- a/examples/init/README.md
+++ b/examples/init/README.md
@@ -86,7 +86,7 @@ cd drupal9
 lando php -v | grep "PHP 8.0"
 
 # Should use a varnish http_resp_hdr_len setting of 25k
-lando varnishadm param.show http_resp_hdr_len | grep 'Value is: 25k'
+lando varnishadm param.show http_resp_hdr_len 2>&1 | grep 'Value is: 25k'
 
 # Should have all pantheon services running and their tooling enabled by defaults
 docker ps --filter label=com.docker.compose.project=landobotdrupal9 | grep landobotdrupal9_appserver_nginx_1

--- a/examples/init/README.md
+++ b/examples/init/README.md
@@ -80,10 +80,14 @@ lando ssh -c "env" | grep PRESSFLOW_SETTINGS | grep pantheon
 lando ssh -c "env" | grep TERMINUS_ENV | grep dev
 lando ssh -c "env" | grep TERMINUS_SITE | grep landobot-drupal9
 lando ssh -c "env" | grep TERMINUS_USER | grep droid@lando.dev
+lando ssh -c "env" | grep PANTHEON_EDGE_HTTP_RESP_HDR_LEN | grep '25k'
 
 # Should use php version in pantheon.upstream.yml
 cd drupal9
 lando php -v | grep "PHP 8.0"
+
+# Should use a varnish http_resp_hdr_len setting of 25k
+lando varnishadm param.show http_resp_hdr_len | grep 'Value is: 25k'
 
 # Should have all pantheon services running and their tooling enabled by defaults
 docker ps --filter label=com.docker.compose.project=landobotdrupal9 | grep landobotdrupal9_appserver_nginx_1

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,6 +16,7 @@ const BACKDRUSH_VERSION = '1.2.0';
 const PANTHEON_CACHE_HOST = 'cache';
 const PANTHEON_CACHE_PORT = '6379';
 const PANTHEON_CACHE_PASSWORD = '';
+const PANTHEON_EDGE_HTTP_RESP_HDR_LEN = '25k';
 const PANTHEON_INDEX_HOST = 'index';
 const PANTHEON_INDEX_PORT = '449';
 const PATH = [
@@ -235,6 +236,7 @@ exports.getPantheonEnvironment = options => ({
   TERMINUS_USER: _.get(options, '_app.meta.email'),
   SECURE_AUTH_KEY: getHash(options.app),
   SECURE_AUTH_SALT: getHash(options.app + options.root),
+  VARNISHD_PARAM_HTTP_RESP_HDR_LEN: PANTHEON_EDGE_HTTP_RESP_HDR_LEN,
 });
 
 /*

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -189,6 +189,11 @@ exports.getPantheonEdge = options => ({
       backends: ['appserver_nginx'],
       ssl: true,
       config: {vcl: path.join(options.confDest, 'pantheon.vcl')},
+      overrides: {
+        environment: {
+          VARNISHD_PARAM_HTTP_RESP_HDR_LEN: PANTHEON_EDGE_HTTP_RESP_HDR_LEN,
+        },
+      },
     },
   },
   tooling: {
@@ -236,7 +241,6 @@ exports.getPantheonEnvironment = options => ({
   TERMINUS_USER: _.get(options, '_app.meta.email'),
   SECURE_AUTH_KEY: getHash(options.app),
   SECURE_AUTH_SALT: getHash(options.app + options.root),
-  VARNISHD_PARAM_HTTP_RESP_HDR_LEN: PANTHEON_EDGE_HTTP_RESP_HDR_LEN,
 });
 
 /*


### PR DESCRIPTION
Cloned over from [PR #110](https://github.com/lando/pantheon/pull/110) to run tests, quoting @apotek:

This pull request is an attempt to address #109 . 

I am basing this approach on the fact that setting my local lando with this:

```yml
  edge:
    overrides:
      environment:
        VARNISHD_PARAM_HTTP_RESP_HDR_LEN: 25k
```
allows the gotpl to build the varnish container with 25k as the setting rather than the default 8k. Can be verified by rebuilding and then issuing the following command:

`lando varnishadm param.show http_resp_hdr_len | grep 'Value is: 25k'`

I cloned my modified plugin to ~/src/lando-plugins/@lando/pantheon and symlinked `~/.lando/plugins -> ~/src/lando-plugins`, which allowed my cloned plugin to override the shipping pluging. 

Then I did a destroy and start and, with these modifications, the max http resp header size allowed  by edge is 25k instead of 8k.

```
% lando varnishadm param.show http_resp_hdr_len

http_resp_hdr_len
        Value is: 25k [bytes]
        Default is: 8k
        Minimum is: 40b
```

which now matches pantheon settings.

----
some interesting history:
 * https://github.com/lando/lando/commit/54dea39bc9126b536c8efb7a19b16ca3ff455137
 * https://github.com/lando/lando/issues/1142
