### PR TITLE
#29: Add an application/json header to Terminus request.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -67,7 +67,7 @@ module.exports = class PantheonApiClient {
    */
   auth(token = this.token) {
     const data = {machine_token: token, client: 'terminus'};
-    const options = (this.mode === 'node') ? {headers: {'User-Agent': 'Terminus/Lando'}} : {};
+    const options = (this.mode === 'node') ? {headers: {'User-Agent': 'Terminus/Lando', 'Content-Type': 'application/json'}} : {};
     const upath = ['authorize', 'machine-token'];
     return pantheonRequest(axios.create({baseURL: this.baseURL}), this.log, 'post', upath, data, options)
     .then(data => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -67,7 +67,8 @@ module.exports = class PantheonApiClient {
    */
   auth(token = this.token) {
     const data = {machine_token: token, client: 'terminus'};
-    const options = (this.mode === 'node') ? {headers: {'User-Agent': 'Terminus/Lando', 'Content-Type': 'application/json'}} : {};
+    const options = (this.mode === 'node') ?
+      {headers: {'User-Agent': 'Terminus/Lando', 'Content-Type': 'application/json'}} : {};
     const upath = ['authorize', 'machine-token'];
     return pantheonRequest(axios.create({baseURL: this.baseURL}), this.log, 'post', upath, data, options)
     .then(data => {


### PR DESCRIPTION
In the past we had reports of a 'request to undefined failed with code 200: undefined.' terminus response error when users tried to connect to Pantheon in a `lando init` call.

Working with a user, they used Postman to recreate the Terminus calls and found that they received this error if they did not include a `Content-Type: application/json` header. We used that header for all our requests aside from the initial call to the Terminus auth endpoint: https://github.com/lando/pantheon/blob/f8409ad8dd9ccbefb451d22d146c651d353aceb4/lib/client.js#L72

Instructions to the user to user this PR branch to test:

```
cd ~/.lando
mkdir plugins/@lando && cd plugins/@lando
git clone git@github.com:lando/pantheon.git && git checkout 29-add-json-header
lando --clear
cd /your/project/directory
# Make sure that you can see the Pantheon plugin using the plugin installed in ~/.lando/plugins/@lando/pantheon
lando config
```

Once you've confirmed that you see the Pantheon plugin in your config output as using your custom installation, try initializing/installing your project as normal.

