### PR TITLE
#112: Update MariaDB available versions to 10.6.

### DIFF
--- a/examples/drupal9/README.md
+++ b/examples/drupal9/README.md
@@ -83,6 +83,10 @@ lando ssh -c "env" | grep TERMINUS_USER | grep droid@lando.dev
 cd drupal9
 lando php -v | grep "PHP 8.0"
 
+# Should use the database version in pantheon.yml
+cd drupal9
+lando ssh -s database -c "mysql -V" | grep 10.6. 
+
 # Should use a varnish http_resp_hdr_len setting of 25k
 cd drupal9
 lando varnishadm param.show http_resp_hdr_len | grep 'Value is: 25k'

--- a/services/pantheon-mariadb/builder.js
+++ b/services/pantheon-mariadb/builder.js
@@ -8,9 +8,10 @@ module.exports = {
   name: 'pantheon-mariadb',
   config: {
     version: '10.3', // @todo: this will probably be 10.3, check D6 support.
-    supported: ['10.4', '10.3', '10.1'],
+    supported: ['10.6', '10.4', '10.3', '10.1'],
     legacy: ['10.1'],
     pinPairs: {
+      '10.6': 'mariadb:10.6.7',
       '10.4': 'mariadb:10.4.21',
       '10.3': 'mariadb:10.3.31',
       '10.1': 'mariadb:10.1.48',


### PR DESCRIPTION
Responding to [Slack comment](https://devwithlando.slack.com/archives/C2XBSHX8R/p1651174390020599) to make MariaDB 10.6 available now that [Pantheon supports it](https://pantheon.io/docs/pantheon-yml#specify-a-version-of-mariadb).

Updated our D9 Pantheon testing site to use it and to test for 10.6 on startup...will need to complete the task in #112 sometime down the pike.