### PR TITLE
Correctly redirect to installer when database is empty with newer versions of PHP

### DIFF
--- a/recipes/pantheon/prepend.php
+++ b/recipes/pantheon/prepend.php
@@ -90,7 +90,11 @@ if (
    * Issue: https://github.com/pantheon-systems/drops-8/issues/139
    *
    */
-  if ((gettype($dbh->exec("SELECT count(*) FROM users")) == 'integer') != 1) {
+  try {
+    if ((gettype($dbh->exec("SELECT count(*) FROM users")) == 'integer') != 1) {
+      $_SERVER['PANTHEON_DATABASE_STATE'] = 'empty';
+    }
+  } catch (PDOException $e) {
     $_SERVER['PANTHEON_DATABASE_STATE'] = 'empty';
   }
 


### PR DESCRIPTION
When the database is empty, using newer versions of PHP (say PHP 8.0), I get this error when visiting the site:

```
Fatal error: Uncaught PDOException: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'pantheon.users' doesn't exist in /srv/includes/prepend.php:93 Stack trace: #0 /srv/includes/prepend.php(93): PDO->exec('SELECT count(*)...') #1 {main} thrown in /srv/includes/prepend.php on line 93
```

What really should happen, is the user should be redirected to the Drupal installer! With this PR that is what happens