### PR TITLE
Gracefully handle the scenario where the DB exists, but has no tables.

### DIFF
--- a/recipes/pantheon/prepend.php
+++ b/recipes/pantheon/prepend.php
@@ -90,7 +90,10 @@ if (
    * Issue: https://github.com/pantheon-systems/drops-8/issues/139
    *
    */
-  if ((gettype($dbh->exec("SELECT count(*) FROM users")) == 'integer') != 1) {
+  if ($dbh->exec("SHOW TABLES LIKE 'users'") !== 'users') {
+    $_SERVER['PANTHEON_DATABASE_STATE'] = 'empty';
+  }
+  elseif ((gettype($dbh->exec("SELECT count(*) FROM users")) == 'integer') != 1) {
     $_SERVER['PANTHEON_DATABASE_STATE'] = 'empty';
   }
 


### PR DESCRIPTION
I've run `lando init && lando start` on a pantheon codebase that has already been setup to work with Lando.  I have not yet pulled a DB.  If I attempt to visit the site in my browser, I get an unhelpful fatal error:

```
Fatal error: Uncaught PDOException: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'pantheon.users' doesn't exist in /srv/includes/prepend.php:93 Stack trace: #0 /srv/includes/prepend.php(93): PDO->exec('SELECT count(*)...') #1 {main} thrown in /srv/includes/prepend.php on line 93 
```

In this scenario we should show the installer, just like we would if the `user` table existed, but was empty.  