### PR TITLE
X-Pantheon-Session should be sent in a header not a cookie.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -75,7 +75,7 @@ module.exports = class PantheonApiClient {
       this.session = data;
       const headers = {'Content-Type': 'application/json'};
       // Add cookie if we are in node mode, otherwise assume its set upstream in the browser
-      if (this.mode === 'node') headers.Cookie = `X-Pantheon-Session=${data.session}`;
+      if (this.mode === 'node') headers['X-Pantheon-Session'] = data.session;
       this.request = axios.create({baseURL: this.baseURL, headers});
       return data;
     });


### PR DESCRIPTION
Hi Lando folks 👋 

At Pantheon we recently made a API change for terminus in which we removed the old way we had (Terminux 0.x) for requests to authenticate to the API using cookies. After we moved 100% of requests to Terminus API we started getting support tickets that Lando is not working for clients.

After taking a look to the code, we found that Lando was using cookies but it should really be using the actual headers.

This PR is UNTESTED, hopefully a guide for you to understand what should happen here.

Thanks!