### PR TITLE
Use lookup endpoint in `lando init` when --pantheon-site is set

### DIFF
--- a/builders/pantheon-php.js
+++ b/builders/pantheon-php.js
@@ -44,6 +44,7 @@ module.exports = {
       // @TODO: this throws a weird DeprecationWarning: 'root' is deprecated, use 'global' for reasons not immediately clear
       // So we are doing this a little weirdly to avoid hat until we can track things down better
       options.volumes.push(`${options.confDest}/prepend.php:/srv/includes/prepend.php`);
+
       // Add in our environment
       options.environment = utils.getPantheonEnvironment(options);
       options.confSrc = path.resolve(__dirname, '..', 'config');

--- a/docs/development.md
+++ b/docs/development.md
@@ -92,20 +92,17 @@ npm run test:unit
 We do end to end testing with our made-just-for-Lando testing framework [Leia](https://github.com/lando/leia). Leia allows us to define tests as a series of commented shell commands in human readable markdown files. Here is a simple example:
 
 ```md
-Start up tests
---------------
+## Start up tests
 
 # Should start up successfully
 lando start
 
-Verification commands
----------------------
+## Verification commands
 
 # Should be able to connect to all mariadb relationships
 lando mariadb main -e "show tables;"
 
-Destroy tests
--------------
+## Destroy tests
 
 # Should be able to destroy our app
 lando destroy -y

--- a/examples/drupal10/README.md
+++ b/examples/drupal10/README.md
@@ -1,5 +1,4 @@
-Pantheon Drupal 10 Example
-=========================
+# Pantheon Drupal 10 Example
 
 This example exists primarily to test the following:
 
@@ -7,8 +6,7 @@ This example exists primarily to test the following:
 
 **Note that you will need to replace (or export) `$PANTHEON_MACHINE_TOKEN` and `--pantheon-site` to values that make sense for you.**
 
-Start up tests
---------------
+## Start up tests
 
 Run the following commands to get up and running with this example.
 
@@ -30,8 +28,7 @@ cd drupal10
 lando pull --code none --database dev --files dev --rsync
 ```
 
-Verification commands
----------------------
+## Verification commands
 
 Run the following commands to validate things are rolling as they should.
 
@@ -125,8 +122,7 @@ lando pull --code live --database none --files none
 lando switch -e tester
 ```
 
-Destroy tests
--------------
+## Destroy tests
 
 Run the following commands to trash this app like nothing ever happened.
 

--- a/examples/drupal7/README.md
+++ b/examples/drupal7/README.md
@@ -1,5 +1,4 @@
-Pantheon Drupal 7 Example
-=========================
+# Pantheon Drupal 7 Example
 
 This example exists primarily to test the following documentation:
 
@@ -7,8 +6,7 @@ This example exists primarily to test the following documentation:
 
 **Note that you will need to replace (or export) `$PANTHEON_MACHINE_TOKEN` and `--pantheon-site` to values that make sense for you.**
 
-Start up tests
---------------
+## Start up tests
 
 Run the following commands to get up and running with this example.
 
@@ -30,8 +28,7 @@ cd drupal7
 lando pull --code none --database dev --files dev --rsync
 ```
 
-Verification commands
----------------------
+## Verification commands
 
 Run the following commands to validate things are rolling as they should.
 
@@ -148,8 +145,7 @@ lando pull --code test --database none --files none
 lando pull --code live --database none --files none
 ```
 
-Destroy tests
--------------
+## Destroy tests
 
 Run the following commands to trash this app like nothing ever happened.
 

--- a/examples/drupal8/README.md
+++ b/examples/drupal8/README.md
@@ -1,5 +1,4 @@
-Pantheon Drupal 8 Example
-=========================
+# Pantheon Drupal 8 Example
 
 This example exists primarily to test the following:
 
@@ -7,8 +6,7 @@ This example exists primarily to test the following:
 
 **Note that you will need to replace (or export) `$PANTHEON_MACHINE_TOKEN` and `--pantheon-site` to values that make sense for you.**
 
-Start up tests
---------------
+## Start up tests
 
 Run the following commands to get up and running with this example.
 
@@ -30,8 +28,7 @@ cd drupal8
 lando pull --code none --database dev --files dev --rsync
 ```
 
-Verification commands
----------------------
+## Verification commands
 
 Run the following commands to validate things are rolling as they should.
 
@@ -125,8 +122,7 @@ lando pull --code live --database none --files none
 lando switch -e testing
 ```
 
-Destroy tests
--------------
+## Destroy tests
 
 Run the following commands to trash this app like nothing ever happened.
 ```bash

--- a/examples/drupal9/README.md
+++ b/examples/drupal9/README.md
@@ -1,5 +1,4 @@
-Pantheon Drupal 9 Example
-=========================
+# Pantheon Drupal 9 Example
 
 This example exists primarily to test the following:
 
@@ -7,8 +6,7 @@ This example exists primarily to test the following:
 
 **Note that you will need to replace (or export) `$PANTHEON_MACHINE_TOKEN` and `--pantheon-site` to values that make sense for you.**
 
-Start up tests
---------------
+## Start up tests
 
 Run the following commands to get up and running with this example.
 
@@ -30,8 +28,7 @@ cd drupal9
 lando pull --code none --database dev --files dev --rsync
 ```
 
-Verification commands
----------------------
+## Verification commands
 
 Run the following commands to validate things are rolling as they should.
 
@@ -128,8 +125,7 @@ lando pull --code live --database none --files none
 lando switch -e tester
 ```
 
-Destroy tests
--------------
+## Destroy tests
 
 Run the following commands to trash this app like nothing ever happened.
 

--- a/examples/init/README.md
+++ b/examples/init/README.md
@@ -1,5 +1,4 @@
-Pantheon Lando Init Example
-=========================
+# Pantheon Lando Init Example
 
 This example exists primarily to test the following:
 
@@ -7,8 +6,7 @@ This example exists primarily to test the following:
 
 **Note that you will need to replace (or export) `$PANTHEON_MACHINE_TOKEN` and `--pantheon-site` to values that make sense for you.**
 
-Start up tests
---------------
+## Start up tests
 
 Run the following commands to get up and running with this example.
 
@@ -32,8 +30,7 @@ cd drupal9
 lando pull --code none --database dev --files dev --rsync
 ```
 
-Verification commands
----------------------
+## Verification commands
 
 Run the following commands to validate things are rolling as they should.
 

--- a/examples/pantheon-downstreamer-1/README.md
+++ b/examples/pantheon-downstreamer-1/README.md
@@ -4,8 +4,7 @@ This example exists primarily to test the following documentation:
 
 * [Pantheon Recipe](https://docs.lando.dev/pantheon/config.html)
 
-Start up tests
---------------
+## Start up tests
 
 Run the following commands to get up and running with this example.
 
@@ -15,8 +14,7 @@ lando poweroff
 lando start
 ```
 
-Verification commands
----------------------
+## Verification commands
 
 Run the following commands to validate things are rolling as they should.
 
@@ -32,8 +30,7 @@ lando exec database -- "cat /opt/bitnami/mariadb/conf/my_custom.cnf" | grep "LAN
 lando mysql -u root -e "show variables;" | grep innodb_lock_wait_timeout | grep 121
 ```
 
-Destroy tests
--------------
+## Destroy tests
 
 Run the following commands to trash this app like nothing ever happened.
 

--- a/examples/pantheon-downstreamer-2/README.md
+++ b/examples/pantheon-downstreamer-2/README.md
@@ -4,8 +4,7 @@ This example exists primarily to test the following documentation:
 
 * [Pantheon Recipe](https://docs.lando.dev/pantheon/config.html)
 
-Start up tests
---------------
+## Start up tests
 
 Run the following commands to get up and running with this example.
 
@@ -15,8 +14,7 @@ lando poweroff
 lando start
 ```
 
-Verification commands
----------------------
+## Verification commands
 
 Run the following commands to validate things are rolling as they should.
 
@@ -41,8 +39,7 @@ lando info --filter service=cache | grep -vq "port: 'not forwarded'"
 lando info --filter service=index | grep -vq "port: 'not forwarded'"
 ```
 
-Destroy tests
--------------
+## Destroy tests
 
 Run the following commands to trash this app like nothing ever happened.
 

--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -1,5 +1,4 @@
-Pantheon WordPress Example
-==========================
+# Pantheon WordPress Example
 
 This example exists primarily to test the following documentation:
 
@@ -7,8 +6,7 @@ This example exists primarily to test the following documentation:
 
 **Note that you will need to replace (or export) `$PANTHEON_MACHINE_TOKEN` and `--pantheon-site` to values that make sense for you.**
 
-Start up tests
---------------
+## Start up tests
 
 Run the following commands to get up and running with this example.
 
@@ -30,8 +28,7 @@ cd wordpress
 lando pull --code none --database dev --files dev
 ```
 
-Verification commands
----------------------
+## Verification commands
 
 Run the following commands to validate things are rolling as they should.
 
@@ -118,8 +115,7 @@ lando pull --code test --database none --files none
 lando pull --code live --database none --files none
 ```
 
-Destroy tests
--------------
+## Destroy tests
 
 Run the following commands to trash this app like nothing ever happened.
 

--- a/examples/wordpressnetworkdomain/README.md
+++ b/examples/wordpressnetworkdomain/README.md
@@ -1,5 +1,4 @@
-Pantheon WordPress Network Domain Example
-==========================
+# Pantheon WordPress Network Domain Example
 
 This example exists primarily to test the following documentation:
 
@@ -7,8 +6,7 @@ This example exists primarily to test the following documentation:
 
 **Note that you will need to replace (or export) `$PANTHEON_MACHINE_TOKEN` and `--pantheon-site` to values that make sense for you.**
 
-Start up tests
---------------
+## Start up tests
 
 Run the following commands to get up and running with this example.
 
@@ -30,8 +28,7 @@ cd wordpress
 lando pull --code none --database dev --files dev
 ```
 
-Verification commands
----------------------
+## Verification commands
 
 Run the following commands to validate things are rolling as they should.
 
@@ -81,8 +78,7 @@ curl -LI http://landobot-network-domain.lndo.site | grep Via || echo $? | grep 1
 curl -L http://site1.landobot-network-folder.lndo.site | grep site1 || echo $? | grep 1
 ```
 
-Destroy tests
--------------
+## Destroy tests
 
 Run the following commands to trash this app like nothing ever happened.
 

--- a/examples/wordpressnetworkfolder/README.md
+++ b/examples/wordpressnetworkfolder/README.md
@@ -1,5 +1,4 @@
-Pantheon WordPress Network Folder Example
-==========================
+# Pantheon WordPress Network Folder Example
 
 This example exists primarily to test the following documentation:
 
@@ -7,8 +6,7 @@ This example exists primarily to test the following documentation:
 
 **Note that you will need to replace (or export) `$PANTHEON_MACHINE_TOKEN` and `--pantheon-site` to values that make sense for you.**
 
-Start up tests
---------------
+## Start up tests
 
 Run the following commands to get up and running with this example.
 
@@ -30,8 +28,7 @@ cd wordpress
 lando pull --code none --database dev --files dev
 ```
 
-Verification commands
----------------------
+## Verification commands
 
 Run the following commands to validate things are rolling as they should.
 
@@ -73,8 +70,7 @@ curl -LI http://landobot-network-folder.lndo.site | grep Via || echo $? | grep 1
 curl -L http://landobot-network-folder.lndo.site/site1 | grep site1 || echo $? | grep 1
 ```
 
-Destroy tests
--------------
+## Destroy tests
 
 Run the following commands to trash this app like nothing ever happened.
 

--- a/inits/pantheon.js
+++ b/inits/pantheon.js
@@ -123,10 +123,9 @@ module.exports = {
       }},
       {name: 'get-git-url', func: (options, lando) => {
         const api = new PantheonApiClient(options['pantheon-auth'], lando.log);
-        return api.auth().then(() => api.getSites(options['pantheon-site'] || ''))
-          .then(site => {
-            options['pantheon-git-url'] = getGitUrl(site[0]);
-          });
+        return api.auth().then(() => api.getSite(options['pantheon-site'], false)).then(site => {
+          options['pantheon-git-url'] = getGitUrl(site);
+        });
       }},
       {name: 'reload-keys', cmd: '/helpers/load-keys.sh --silent', user: 'root'},
       {name: 'clone-repo', cmd: options => `/helpers/get-remote-url.sh ${options['pantheon-git-url']}`, remove: 'true'},
@@ -157,12 +156,12 @@ module.exports = {
       .then(() => api.auth())
       // Get our sites and user
       .then(() => {
-        return Promise.all([api.getSites(options['pantheon-site'] || ''), api.getUser()]);
+        return Promise.all([api.getSite(options['pantheon-site']), api.getUser()]);
       })
       // Parse the dataz and set the things
       .then(results => {
         // Get our site and email
-        const site = _.head(_.filter(results[0], site => site.name === options['pantheon-site']));
+        const site = results[0];
         const user = results[1];
 
         // Error if site doesn't exist

--- a/lib/client.js
+++ b/lib/client.js
@@ -81,6 +81,18 @@ module.exports = class PantheonApiClient {
     });
   };
 
+  /*
+   * Get site information
+   */
+  getSite(site, full = true) {
+    return pantheonRequest(this.request, this.log, 'get', ['site-names', site]).then(site => {
+      // if not full then just return the lookup
+      if (!full) return site;
+      // otherwise return the full site
+      return pantheonRequest(this.request, this.log, 'get', ['sites', site.id]);
+    });
+  };
+
   /**
    * Get sites available to the user, optionally filtering by a specific site name.
    *
@@ -90,37 +102,31 @@ module.exports = class PantheonApiClient {
    *  A promise that resolves with an array of site objects.
    */
   getSites(lookup = '') {
-    if (lookup) {
-      // Lookup a single site
-      return pantheonRequest(this.request, this.log, 'get', ['site-names', lookup])
-        .then(site => [site]);
-    } else {
-      // Call to get user sites
-      const pantheonUserSites = () => {
-        const getSites = ['users', _.get(this.session, 'user_id'), 'memberships', 'sites'];
-        return pantheonRequest(this.request, this.log, 'get', getSites, {params: {limit: MAX_SITES}})
-          .then(sites => _.map(sites, (site, id) => _.merge(site, site.site)));
-      };
-      // Call to get org sites
-      const pantheonOrgSites = () => {
-        const getOrgs = ['users', _.get(this.session, 'user_id'), 'memberships', 'organizations'];
-        return pantheonRequest(this.request, this.log, 'get', getOrgs)
-          .map(org => {
-            if (org.role !== 'unprivileged') {
-              const getOrgsSites = ['organizations', org.id, 'memberships', 'sites'];
-              return pantheonRequest(this.request, this.log, 'get', getOrgsSites, {params: {limit: MAX_SITES}})
-                .map(site => _.merge(site, site.site));
-            }
-          })
-          .then(sites => _.flatten(sites));
-      };
-      // Run both requests
-      return Promise.all([pantheonUserSites(), pantheonOrgSites()])
-        // Combine, cache and all the things
-        .then(sites => _.compact(_.sortBy(_.uniqBy(_.flatten(sites), 'name'), 'name')))
-        // Filter out any BAAAAD BIZZZNIZZZ
-        .filter(site => !site.frozen);
-    }
+    // Call to get user sites
+    const pantheonUserSites = () => {
+      const getSites = ['users', _.get(this.session, 'user_id'), 'memberships', 'sites'];
+      return pantheonRequest(this.request, this.log, 'get', getSites, {params: {limit: MAX_SITES}})
+        .then(sites => _.map(sites, (site, id) => _.merge(site, site.site)));
+    };
+    // Call to get org sites
+    const pantheonOrgSites = () => {
+      const getOrgs = ['users', _.get(this.session, 'user_id'), 'memberships', 'organizations'];
+      return pantheonRequest(this.request, this.log, 'get', getOrgs)
+        .map(org => {
+          if (org.role !== 'unprivileged') {
+            const getOrgsSites = ['organizations', org.id, 'memberships', 'sites'];
+            return pantheonRequest(this.request, this.log, 'get', getOrgsSites, {params: {limit: MAX_SITES}})
+              .map(site => _.merge(site, site.site));
+          }
+        })
+        .then(sites => _.flatten(sites));
+    };
+    // Run both requests
+    return Promise.all([pantheonUserSites(), pantheonOrgSites()])
+      // Combine, cache and all the things
+      .then(sites => _.compact(_.sortBy(_.uniqBy(_.flatten(sites), 'name'), 'name')))
+      // Filter out any BAAAAD BIZZZNIZZZ
+      .filter(site => !site.frozen);
   };
 
  /*

--- a/lib/client.js
+++ b/lib/client.js
@@ -81,35 +81,46 @@ module.exports = class PantheonApiClient {
     });
   };
 
-  /*
-   * Get list of sites
+  /**
+   * Get sites available to the user, optionally filtering by a specific site name.
+   *
+   * @param {string?} lookup
+   *  The name of the site to look up.
+   * @return {Promise}
+   *  A promise that resolves with an array of site objects.
    */
-  getSites() {
-    // Call to get user sites
-    const pantheonUserSites = () => {
-      const getSites = ['users', _.get(this.session, 'user_id'), 'memberships', 'sites'];
-      return pantheonRequest(this.request, this.log, 'get', getSites, {params: {limit: MAX_SITES}})
-      .then(sites => _.map(sites, (site, id) => _.merge(site, site.site)));
-    };
-    // Call to get org sites
-    const pantheonOrgSites = () => {
-      const getOrgs = ['users', _.get(this.session, 'user_id'), 'memberships', 'organizations'];
-      return pantheonRequest(this.request, this.log, 'get', getOrgs)
-      .map(org => {
-        if (org.role !== 'unprivileged') {
-          const getOrgsSites = ['organizations', org.id, 'memberships', 'sites'];
-          return pantheonRequest(this.request, this.log, 'get', getOrgsSites, {params: {limit: MAX_SITES}})
-          .map(site => _.merge(site, site.site));
-        }
-      })
-      .then(sites => _.flatten(sites));
-    };
-    // Run both requests
-    return Promise.all([pantheonUserSites(), pantheonOrgSites()])
-    // Combine, cache and all the things
-    .then(sites => _.compact(_.sortBy(_.uniqBy(_.flatten(sites), 'name'), 'name')))
-    // Filter out any BAAAAD BIZZZNIZZZ
-    .filter(site => !site.frozen);
+  getSites(lookup = '') {
+    if (lookup) {
+      // Lookup a single site
+      return pantheonRequest(this.request, this.log, 'get', ['site-names', lookup])
+        .then(site => [site]);
+    } else {
+      // Call to get user sites
+      const pantheonUserSites = () => {
+        const getSites = ['users', _.get(this.session, 'user_id'), 'memberships', 'sites'];
+        return pantheonRequest(this.request, this.log, 'get', getSites, {params: {limit: MAX_SITES}})
+          .then(sites => _.map(sites, (site, id) => _.merge(site, site.site)));
+      };
+      // Call to get org sites
+      const pantheonOrgSites = () => {
+        const getOrgs = ['users', _.get(this.session, 'user_id'), 'memberships', 'organizations'];
+        return pantheonRequest(this.request, this.log, 'get', getOrgs)
+          .map(org => {
+            if (org.role !== 'unprivileged') {
+              const getOrgsSites = ['organizations', org.id, 'memberships', 'sites'];
+              return pantheonRequest(this.request, this.log, 'get', getOrgsSites, {params: {limit: MAX_SITES}})
+                .map(site => _.merge(site, site.site));
+            }
+          })
+          .then(sites => _.flatten(sites));
+      };
+      // Run both requests
+      return Promise.all([pantheonUserSites(), pantheonOrgSites()])
+        // Combine, cache and all the things
+        .then(sites => _.compact(_.sortBy(_.uniqBy(_.flatten(sites), 'name'), 'name')))
+        // Filter out any BAAAAD BIZZZNIZZZ
+        .filter(site => !site.frozen);
+    }
   };
 
  /*


### PR DESCRIPTION
When running init for a pantheon recipe, a list of all of the user's sites is fetched and presented to the user so that they can select their site. If a user has many, many thousands of sites, the API call crashes pantheon's terminus endpoint, returning 50x errors, which crashes lando's init process. A user can't use `lando init` in this situation. Even when specifying the site with the `--pantheon-site` param, the list of sites is still requested in order to check that the value provided matches a valid site.

This PR add's a parameter to the getSites() method to alter the API request that is used so that the lookup endpoint is used to validate the provided site name rather than comparing against the full list. This improves performance every time the parameter is used, but more importantly, it keeps those with many thousands of sites from experiencing a crash when trying to lando init.