### PR TITLE
Update the drush version to latest release

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,7 +18,7 @@ const path = require('path');
 const yaml = require('js-yaml');
 
 // Constants
-const DRUSH_VERSION = '8.3.5';
+const DRUSH_VERSION = '8.5.0';
 const BACKDRUSH_VERSION = '1.2.0';
 const PANTHEON_CACHE_HOST = 'cache';
 const PANTHEON_CACHE_PORT = '6379';


### PR DESCRIPTION
This bumps the version of Drush used by the plugin to the latest 8.5.0 and fixes issue #253

Fixes #253 


### Bare minimum self-checks

> [What do you think of a person who only does the bare minimum?](https://getyarn.io/yarn-clip/dcf80710-425e-478b-bde1-c107bd11e849)

- [x] I've updated this PR with the latest code from `main`
- [x] I've done a cursory QA pass of my code locally
- [ ] I've ensured all automated status check and tests pass
- [x] I've [connected this PR to an issue](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues)

### Pieces of flare

- [ ] I've written a unit or functional test for my code
- [ ] I've updated relevant documentation it my code changes it
- [ ] I've updated this repo's README if my code changes it
- [ ] I've updated this repo's CHANGELOG with my change unless its a trivial change (like updating a typo in the docs)

### Finally

- [ ] I've [requested a review](https://help.github.com/en/articles/requesting-a-pull-request-review) with relevant people

If you have any issues or need help please join the `#contributors` channel in the [Lando slack](https://www.launchpass.com/devwithlando) and someone will gladly help you out!

You can also check out the [coder guide](https://docs.lando.dev/contrib/coder.html).
