### PR TITLE
fix: stop overriding robots.txt in Pantheon templates

### DIFF
--- a/config/backdrop.conf.tpl
+++ b/config/backdrop.conf.tpl
@@ -68,13 +68,6 @@ server {
     location ~ /sites/default/files/.*\.php$ {
         return 403;
     }
-    location ~ ^/robots.txt {
-        add_header X-Pantheon-Site TBD always;
-        add_header X-Pantheon-Environment lando always;
-        add_header Cache-Control max-age=86000;
-        root /srv/error_pages;
-    }
-
     # Web fonts support.
     location ~* \.(eot|ttf|woff|woff2|otf|svg)$ {
         auth_basic $auth_basic_realm;

--- a/config/drupal.conf.tpl
+++ b/config/drupal.conf.tpl
@@ -68,13 +68,6 @@ server {
     location ~ /sites/default/files/.*\.php$ {
         return 403;
     }
-    location ~ ^/robots.txt {
-        add_header X-Pantheon-Site TBD always;
-        add_header X-Pantheon-Environment lando always;
-        add_header Cache-Control max-age=86000;
-        root /srv/error_pages;
-    }
-
     # Web fonts support.
     location ~* \.(eot|ttf|woff|woff2|otf|svg)$ {
         auth_basic $auth_basic_realm;

--- a/config/drupal10.conf.tpl
+++ b/config/drupal10.conf.tpl
@@ -68,13 +68,6 @@ server {
     location ~ /sites/default/files/.*\.php$ {
         return 403;
     }
-    location ~ ^/robots.txt {
-        add_header X-Pantheon-Site TBD always;
-        add_header X-Pantheon-Environment lando always;
-        add_header Cache-Control max-age=86000;
-        root /srv/error_pages;
-    }
-
     # Web fonts support.
     location ~* \.(eot|ttf|woff|woff2|otf|svg)$ {
         auth_basic $auth_basic_realm;

--- a/config/drupal8.conf.tpl
+++ b/config/drupal8.conf.tpl
@@ -68,13 +68,6 @@ server {
     location ~ /sites/default/files/.*\.php$ {
         return 403;
     }
-    location ~ ^/robots.txt {
-        add_header X-Pantheon-Site TBD always;
-        add_header X-Pantheon-Environment lando always;
-        add_header Cache-Control max-age=86000;
-        root /srv/error_pages;
-    }
-
     # Web fonts support.
     location ~* \.(eot|ttf|woff|woff2|otf|svg)$ {
         auth_basic $auth_basic_realm;

--- a/config/drupal9.conf.tpl
+++ b/config/drupal9.conf.tpl
@@ -68,13 +68,6 @@ server {
     location ~ /sites/default/files/.*\.php$ {
         return 403;
     }
-    location ~ ^/robots.txt {
-        add_header X-Pantheon-Site TBD always;
-        add_header X-Pantheon-Environment lando always;
-        add_header Cache-Control max-age=86000;
-        root /srv/error_pages;
-    }
-
     # Web fonts support.
     location ~* \.(eot|ttf|woff|woff2|otf|svg)$ {
         auth_basic $auth_basic_realm;

--- a/config/wordpress.conf.tpl
+++ b/config/wordpress.conf.tpl
@@ -66,13 +66,6 @@ server {
     location ~ /sites/default/files/.*\.php$ {
         return 403;
     }
-    location ~ ^/robots.txt {
-        add_header X-Pantheon-Site TBD always;
-        add_header X-Pantheon-Environment lando always;
-        add_header Cache-Control max-age=86000;
-        root /srv/error_pages;
-    }
-
     # Web fonts support.
     location ~* \.(eot|ttf|woff|woff2|otf|svg)$ {
         auth_basic $auth_basic_realm;

--- a/config/wordpress_network.conf.tpl
+++ b/config/wordpress_network.conf.tpl
@@ -66,13 +66,6 @@ server {
     location ~ /sites/default/files/.*\.php$ {
         return 403;
     }
-    location ~ ^/robots.txt {
-        add_header X-Pantheon-Site TBD always;
-        add_header X-Pantheon-Environment lando always;
-        add_header Cache-Control max-age=86000;
-        root /srv/error_pages;
-    }
-
     # Web fonts support.
     location ~* \.(eot|ttf|woff|woff2|otf|svg)$ {
         auth_basic $auth_basic_realm;


### PR DESCRIPTION
## Summary

Removes the special `/robots.txt` override from Pantheon nginx templates so apps can serve their own `robots.txt`.

Fixes #349.

## Testing

- Ran `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request routing for `/robots.txt` across all Pantheon nginx templates, which can affect crawler behavior and caching semantics. Low implementation complexity, but user-visible SEO/crawl impact if sites relied on the previous fixed response/headers.
> 
> **Overview**
> Stops the Pantheon nginx templates from **special-casing `/robots.txt`** (including custom headers/cache-control and serving from `/srv/error_pages`).
> 
> As a result, Drupal/Backdrop/WordPress projects can now serve their own `robots.txt` through the normal static/cleanurl routing in `backdrop.conf.tpl`, `drupal*.conf.tpl`, and `wordpress*.conf.tpl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3005126971e1e0a7ba79ecd8f30564b6dc0a0d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->