### PR TITLE
feat: add support for pantheon.yml frontend_build

### DIFF
--- a/.github/workflows/pr-pantheon-tests.yml
+++ b/.github/workflows/pr-pantheon-tests.yml
@@ -28,6 +28,7 @@ jobs:
           - examples/pantheon-downstreamer-1
           - examples/pantheon-downstreamer-2
           - examples/pantheon-drush-uri
+          - examples/frontend-build
           - examples/wordpress
           - examples/wordpressnetworkdomain
           # - examples/wordpressnetworkfolder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
-* Added support for Pantheon `frontend_build` via a Node sidecar, lockfile-based installs, and `lando frontend-build` / `lando npm` / `yarn` / `pnpm` / `bun` tooling
+* Added support for Pantheon `frontend_build` via a Node sidecar, lockfile-based installs, `lando frontend-build`, and package-manager tooling that appears only for configured lockfiles
 
 ## v1.14.0 - [June 4, 2026](https://github.com/lando/pantheon/releases/tag/v1.14.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Added support for Pantheon `frontend_build` via a Node sidecar, lockfile-based installs, and `lando frontend-build` / `lando npm` / `yarn` / `pnpm` / `bun` tooling
+
 ## v1.14.0 - [June 4, 2026](https://github.com/lando/pantheon/releases/tag/v1.14.0)
 
 * Added Solr `9` support [#362](https://github.com/lando/pantheon/pull/362)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
-* Added support for Pantheon `frontend_build` via a Node sidecar, lockfile-based installs, `lando frontend-build`, and package-manager tooling that appears only for configured lockfiles
+* Added support for Pantheon `frontend_build`
 
 ## v1.14.0 - [June 4, 2026](https://github.com/lando/pantheon/releases/tag/v1.14.0)
 

--- a/builders/pantheon-node.js
+++ b/builders/pantheon-node.js
@@ -3,8 +3,8 @@
 const _ = require('lodash');
 const fs = require('fs');
 const path = require('path');
-const landoNodePath = path.join(__dirname, '../node_modules/@lando/node');
-const LandoNode = require(`${landoNodePath}/builders/node.js`);
+const LandoNode = require('@lando/node/builders/node.js');
+const landoNodePath = path.resolve(path.dirname(require.resolve('@lando/node/builders/node.js')), '..');
 
 const EXTRA_VERSIONS = [
   '26', '26.7', '26.6', '26.5', '26.4', '26.3', '26.2', '26.1',

--- a/builders/pantheon-node.js
+++ b/builders/pantheon-node.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const _ = require('lodash');
+const fs = require('fs');
+const path = require('path');
+const landoNodePath = path.join(__dirname, '../node_modules/@lando/node');
+const LandoNode = require(`${landoNodePath}/builders/node.js`);
+
+const EXTRA_VERSIONS = [
+  '26', '26.7', '26.6', '26.5', '26.4', '26.3', '26.2', '26.1',
+  '24', '24.19',
+  '22', '22.23',
+];
+
+const loadScripts = options => {
+  const lando = _.get(options, '_app._lando');
+  if (lando && fs.existsSync(path.join(landoNodePath, 'scripts'))) {
+    const confDir = path.join(lando.config.userConfRoot, 'scripts');
+    const dest = lando.utils.moveConfig(path.join(landoNodePath, 'scripts'), confDir);
+    lando.utils.makeExecutable(fs.readdirSync(dest), dest);
+  }
+};
+
+const nodeConfig = _.merge({}, LandoNode.config, {
+  supported: _.uniq(EXTRA_VERSIONS.concat(LandoNode.config.supported || [])),
+});
+
+module.exports = {
+  name: 'pantheon-node',
+  parent: '_appserver',
+  builder: parent => class PantheonNode extends LandoNode.builder(parent, nodeConfig) {
+    constructor(id, options = {}, factory) {
+      loadScripts(options);
+      super(id, options, factory);
+    }
+  },
+};

--- a/builders/pantheon.js
+++ b/builders/pantheon.js
@@ -10,6 +10,7 @@ const push = require('../lib/push');
 const change = require('../lib/switch');
 const mysql = require('../lib/mysql');
 const utils = require('../lib/utils');
+const frontendBuild = require('../lib/frontend-build');
 
 const setTooling = (options, tokens) => {
   const metaToken = _.get(
@@ -195,6 +196,13 @@ module.exports = {
 
       options = setTooling(options, tokens);
       options = setBuildSteps(options);
+
+      if (options.frontendBuild) {
+        const plan = frontendBuild.resolveFrontendBuild(options.frontendBuild, options.root);
+        const extra = frontendBuild.getPantheonFrontend(plan);
+        options.services = _.merge({}, options.services, extra.services);
+        options.tooling = _.merge({}, options.tooling, extra.tooling);
+      }
 
       // Add appserver and database services.
       options.services = _.merge({}, getServices(options), options.services);

--- a/docs/config.md
+++ b/docs/config.md
@@ -50,6 +50,24 @@ search:
   version: 8
 ```
 
+## Frontend builds
+
+If your `pantheon.yml` has a [`frontend_build`](https://docs.pantheon.io/frontend-builds) block, Lando starts an invisible Node sidecar and runs the same install + build as Pantheon. You do not need extra Node config in your Landofile.
+
+```yaml
+api_version: 1
+frontend_build:
+  paths:
+    - path: web/themes/custom/mytheme
+      node_version: 26
+      build_command: build
+```
+
+* Node `22`, `24`, and `26` (default `26`). Mixed majors across paths are refused.
+* Package manager comes from the lockfile in each path, in Pantheon order: bun, pnpm, yarn, npm. No lockfile fails that path.
+* Builds run on `lando start` / `lando rebuild`. Use `lando frontend-build` to run them again.
+* `lando npm`, `lando yarn`, `lando pnpm`, `lando bun`, and `lando node` run in the first build path so `lando npm run watch` works.
+
 Supported Solr versions: `8` and `9`.
 
 ## Choosing a nested webroot

--- a/docs/config.md
+++ b/docs/config.md
@@ -66,7 +66,7 @@ frontend_build:
 * Node `22`, `24`, and `26` (default `26`). Mixed majors across paths are refused.
 * Package manager comes from the lockfile in each path, in Pantheon order: bun, pnpm, yarn, npm. No lockfile fails that path.
 * Builds run on `lando start` / `lando rebuild`. Use `lando frontend-build` to run them again.
-* `lando npm`, `lando yarn`, `lando pnpm`, `lando bun`, and `lando node` run in your current directory, same as other Lando tooling. `cd` into the theme and run `lando npm run watch`.
+* `lando node` plus the package managers your lockfiles need (`lando npm`, `lando yarn`, `lando pnpm`, and/or `lando bun`) show up only when `frontend_build` is configured. They run in your current directory.
 
 Supported Solr versions: `8` and `9`.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -66,7 +66,7 @@ frontend_build:
 * Node `22`, `24`, and `26` (default `26`). Mixed majors across paths are refused.
 * Package manager comes from the lockfile in each path, in Pantheon order: bun, pnpm, yarn, npm. No lockfile fails that path.
 * Builds run on `lando start` / `lando rebuild`. Use `lando frontend-build` to run them again.
-* `lando npm`, `lando yarn`, `lando pnpm`, `lando bun`, and `lando node` run in the first build path so `lando npm run watch` works.
+* `lando npm`, `lando yarn`, `lando pnpm`, `lando bun`, and `lando node` run in your current directory, same as other Lando tooling. `cd` into the theme and run `lando npm run watch`.
 
 Supported Solr versions: `8` and `9`.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -50,6 +50,8 @@ search:
   version: 8
 ```
 
+Supported Solr versions: `8` and `9`.
+
 ## Frontend builds
 
 If your `pantheon.yml` has a [`frontend_build`](https://docs.pantheon.io/frontend-builds) block, Lando starts an invisible Node sidecar and runs the same install + build as Pantheon. You do not need extra Node config in your Landofile.
@@ -67,8 +69,6 @@ frontend_build:
 * Package manager comes from the lockfile in each path, in Pantheon order: bun, pnpm, yarn, npm. No lockfile fails that path.
 * Builds run on `lando start` / `lando rebuild`. Use `lando frontend-build` to run them again.
 * `lando node` plus the package managers your lockfiles need (`lando npm`, `lando yarn`, `lando pnpm`, and/or `lando bun`) show up only when `frontend_build` is configured. They run in your current directory.
-
-Supported Solr versions: `8` and `9`.
 
 ## Choosing a nested webroot
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -20,11 +20,11 @@ lando push              Push code, database and/or files to Pantheon
 lando switch            Switch to a different multidev environment
 lando terminus          Runs terminus commands
 lando frontend-build    Builds pantheon.yml frontend_build paths
-lando npm               Runs npm in the first frontend_build path
-lando yarn              Runs yarn in the first frontend_build path
-lando pnpm              Runs pnpm in the first frontend_build path
-lando bun               Runs bun in the first frontend_build path
-lando node              Runs node in the first frontend_build path
+lando npm               Runs npm in the current directory
+lando yarn              Runs yarn in the current directory
+lando pnpm              Runs pnpm in the current directory
+lando bun               Runs bun in the current directory
+lando node              Runs node in the current directory
 lando version           Displays the lando version
 ```
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -24,21 +24,6 @@ lando version           Displays the lando version
 
 **Note that the above commands can differ by your recipes `framework`.** The above are for `framework: drupal8`. We recommend you run `lando` in your app for a complete and up to date listing of your tooling.
 
-## Frontend builds
-
-These commands are **not** part of every Pantheon app. They only appear when `pantheon.yml` has a `frontend_build` block, and only for the package managers your lockfiles actually use.
-
-```bash
-lando frontend-build    Builds every frontend_build path
-lando node              Runs node in the current directory
-lando npm               Present when a path uses package-lock.json
-lando yarn              Present when a path uses yarn.lock
-lando pnpm              Present when a path uses pnpm-lock.yaml
-lando bun               Present when a path uses bun.lock or bun.lockb
-```
-
-They run in your current directory. `cd` into the theme and use `lando npm run watch`, or whichever command your lockfile enabled.
-
 ```bash
 # Login to terminus with a machine token
 lando terminus auth:login --machine-token=MYSPECIALTOKEN
@@ -57,6 +42,21 @@ lando composer require "drupal/search_api_pantheon ~1.0" --prefer-dist
 # Download a backdrop dependency
 lando drush dl webform
 ```
+
+## Frontend builds
+
+These commands are **not** part of every Pantheon app. They only appear when `pantheon.yml` has a `frontend_build` block, and only for the package managers your lockfiles actually use.
+
+```bash
+lando frontend-build    Builds every frontend_build path
+lando node              Runs node in the current directory
+lando npm               Present when a path uses package-lock.json
+lando yarn              Present when a path uses yarn.lock
+lando pnpm              Present when a path uses pnpm-lock.yaml
+lando bun               Present when a path uses bun.lock or bun.lockb
+```
+
+They run in your current directory. `cd` into the theme and use `lando npm run watch`, or whichever command your lockfile enabled.
 
 ## Customizing Pantheon tooling
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -19,16 +19,25 @@ lando pull              Pull code, database and/or files from Pantheon
 lando push              Push code, database and/or files to Pantheon
 lando switch            Switch to a different multidev environment
 lando terminus          Runs terminus commands
-lando frontend-build    Builds pantheon.yml frontend_build paths
-lando npm               Runs npm in the current directory
-lando yarn              Runs yarn in the current directory
-lando pnpm              Runs pnpm in the current directory
-lando bun               Runs bun in the current directory
-lando node              Runs node in the current directory
 lando version           Displays the lando version
 ```
 
 **Note that the above commands can differ by your recipes `framework`.** The above are for `framework: drupal8`. We recommend you run `lando` in your app for a complete and up to date listing of your tooling.
+
+## Frontend builds
+
+These commands are **not** part of every Pantheon app. They only appear when `pantheon.yml` has a `frontend_build` block, and only for the package managers your lockfiles actually use.
+
+```bash
+lando frontend-build    Builds every frontend_build path
+lando node              Runs node in the current directory
+lando npm               Present when a path uses package-lock.json
+lando yarn              Present when a path uses yarn.lock
+lando pnpm              Present when a path uses pnpm-lock.yaml
+lando bun               Present when a path uses bun.lock or bun.lockb
+```
+
+They run in your current directory. `cd` into the theme and use `lando npm run watch`, or whichever command your lockfile enabled.
 
 ```bash
 # Login to terminus with a machine token

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -19,6 +19,12 @@ lando pull              Pull code, database and/or files from Pantheon
 lando push              Push code, database and/or files to Pantheon
 lando switch            Switch to a different multidev environment
 lando terminus          Runs terminus commands
+lando frontend-build    Builds pantheon.yml frontend_build paths
+lando npm               Runs npm in the first frontend_build path
+lando yarn              Runs yarn in the first frontend_build path
+lando pnpm              Runs pnpm in the first frontend_build path
+lando bun               Runs bun in the first frontend_build path
+lando node              Runs node in the first frontend_build path
 lando version           Displays the lando version
 ```
 

--- a/examples/frontend-build/.lando.yml
+++ b/examples/frontend-build/.lando.yml
@@ -1,0 +1,15 @@
+name: lando-pantheon-frontend-build
+recipe: pantheon
+config:
+  framework: drupal
+  site: fake-site
+  id: fake-id
+  cache: false
+  edge: false
+  index: false
+
+# do not remove this
+plugins:
+  "@lando/pantheon": ../..
+  "@lando/mariadb": ../../node_modules/@lando/mariadb
+  "@lando/node": ../../node_modules/@lando/node

--- a/examples/frontend-build/README.md
+++ b/examples/frontend-build/README.md
@@ -25,13 +25,13 @@ Run the following commands to validate things are rolling as they should.
 cat web/themes/custom/demo/dist/built.txt | grep built
 
 # Should expose frontend-build tooling
-lando | grep frontend-build
+lando frontend-build --help
 
 # Should expose npm because this path has package-lock.json
-lando | grep "lando npm"
+lando npm --version
 
 # Should expose node
-lando | grep "lando node"
+lando node --version
 
 # Should rebuild the theme without a full rebuild
 rm -rf web/themes/custom/demo/dist

--- a/examples/frontend-build/README.md
+++ b/examples/frontend-build/README.md
@@ -1,0 +1,56 @@
+# Pantheon Frontend Build Example
+
+This example exists primarily to test Pantheon `frontend_build` support:
+
+* [Pantheon Recipe - Frontend builds](https://docs.lando.dev/plugins/pantheon/config.html#frontend-builds)
+
+## Start up tests
+
+Run the following commands to get up and running with this example.
+
+```bash
+# Should poweroff
+lando poweroff
+
+# Should start up successfully
+lando start
+```
+
+## Verification commands
+
+Run the following commands to validate things are rolling as they should.
+
+```bash
+# Should compile the theme during start
+cat web/themes/custom/demo/dist/built.txt | grep built
+
+# Should expose frontend-build tooling
+lando | grep frontend-build
+
+# Should expose npm because this path has package-lock.json
+lando | grep "lando npm"
+
+# Should expose node
+lando | grep "lando node"
+
+# Should rebuild the theme without a full rebuild
+rm -rf web/themes/custom/demo/dist
+lando frontend-build
+cat web/themes/custom/demo/dist/built.txt | grep built
+
+# Should run npm in the current directory
+cd web/themes/custom/demo
+rm -rf dist
+lando npm run build
+cat dist/built.txt | grep built
+```
+
+## Destroy tests
+
+Run the following commands to trash this app like nothing ever happened.
+
+```bash
+# Should be destroyed with success
+lando destroy -y
+lando poweroff
+```

--- a/examples/frontend-build/index.php
+++ b/examples/frontend-build/index.php
@@ -1,0 +1,2 @@
+<?php
+phpinfo();

--- a/examples/frontend-build/pantheon.yml
+++ b/examples/frontend-build/pantheon.yml
@@ -1,0 +1,7 @@
+api_version: 1
+php_version: 8.3
+frontend_build:
+  paths:
+    - path: web/themes/custom/demo
+      node_version: 26
+      build_command: build

--- a/examples/frontend-build/web/themes/custom/demo/.gitignore
+++ b/examples/frontend-build/web/themes/custom/demo/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/examples/frontend-build/web/themes/custom/demo/build.js
+++ b/examples/frontend-build/web/themes/custom/demo/build.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const dest = path.join(__dirname, 'dist');
+fs.mkdirSync(dest, {recursive: true});
+fs.writeFileSync(path.join(dest, 'built.txt'), 'built\n');

--- a/examples/frontend-build/web/themes/custom/demo/package-lock.json
+++ b/examples/frontend-build/web/themes/custom/demo/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "lando-pantheon-frontend-demo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lando-pantheon-frontend-demo"
+    }
+  }
+}

--- a/examples/frontend-build/web/themes/custom/demo/package.json
+++ b/examples/frontend-build/web/themes/custom/demo/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "lando-pantheon-frontend-demo",
+  "private": true,
+  "scripts": {
+    "build": "node build.js"
+  }
+}

--- a/lib/frontend-build.js
+++ b/lib/frontend-build.js
@@ -125,15 +125,14 @@ const getBuildCommands = plan => bootstrapCommands(plan).concat(pathCommands(pla
 const getPantheonFrontend = plan => {
   const tooling = {
     'node': {service: 'frontend', cmd: 'node'},
-    'npm': {service: 'frontend', cmd: 'npm'},
-    'yarn': {service: 'frontend', cmd: 'yarn'},
-    'pnpm': {service: 'frontend', cmd: 'pnpm'},
-    'bun': {service: 'frontend', cmd: 'bun'},
     'frontend-build': {
       service: 'frontend',
       cmd: getBuildCommands(plan).join(' && '),
     },
   };
+  _.uniq(plan.paths.map(item => item.manager)).forEach(manager => {
+    tooling[manager] = {service: 'frontend', cmd: manager};
+  });
   return {
     services: {
       frontend: {

--- a/lib/frontend-build.js
+++ b/lib/frontend-build.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const _ = require('lodash');
+
+const SUPPORTED_MAJORS = [22, 24, 26];
+const DEFAULT_NODE_VERSION = '26';
+const DEFAULT_BUILD_COMMAND = 'build';
+const LOCKFILES = [
+  {manager: 'bun', files: ['bun.lock', 'bun.lockb']},
+  {manager: 'pnpm', files: ['pnpm-lock.yaml']},
+  {manager: 'yarn', files: ['yarn.lock']},
+  {manager: 'npm', files: ['package-lock.json']},
+];
+const INSTALL_FLAGS = {
+  bun: 'install --frozen-lockfile',
+  pnpm: 'install --frozen-lockfile',
+  yarn: 'install --frozen-lockfile',
+  npm: 'ci',
+};
+const BOOTSTRAP = {
+  yarn: 'command -v yarn >/dev/null 2>&1 || npm install --global yarn',
+  pnpm: 'command -v pnpm >/dev/null 2>&1 || npm install --global pnpm',
+  bun: 'command -v bun >/dev/null 2>&1 || npm install --global bun',
+};
+
+const shQuote = value => `'${String(value).replace(/'/g, `'\\''`)}'`;
+
+const asEntry = entry => {
+  if (_.isString(entry)) return {path: entry};
+  return _.isPlainObject(entry) ? entry : {};
+};
+
+const majorOf = version => parseInt(String(version).split('.')[0], 10);
+
+const normalizeEntry = entry => {
+  const raw = asEntry(entry);
+  const relPath = _.trim(_.toString(raw.path || ''));
+  if (!relPath) {
+    throw new Error('frontend_build path is missing');
+  }
+  const nodeVersion = _.toString(raw.node_version || DEFAULT_NODE_VERSION);
+  const major = majorOf(nodeVersion);
+  if (!SUPPORTED_MAJORS.includes(major)) {
+    throw new Error(`${relPath}: node_version ${nodeVersion} is not supported. Use 22, 24, or 26.`);
+  }
+  return {
+    path: relPath,
+    nodeVersion,
+    major,
+    buildCommand: _.toString(raw.build_command || DEFAULT_BUILD_COMMAND),
+  };
+};
+
+const collectPaths = docs => {
+  const byPath = new Map();
+  _.forEach(docs, doc => {
+    _.forEach(_.get(doc, 'frontend_build.paths', []), entry => {
+      const normalized = normalizeEntry(entry);
+      byPath.set(normalized.path, normalized);
+    });
+  });
+  return [...byPath.values()];
+};
+
+const parseFrontendBuild = docs => {
+  const paths = collectPaths(docs);
+  if (_.isEmpty(paths)) return null;
+
+  const majors = _.uniq(paths.map(item => item.major));
+  if (majors.length > 1) {
+    const detail = paths.map(item => `${item.path} (node ${item.nodeVersion})`).join(', ');
+    throw new Error(`frontend_build paths request mixed Node majors. Use one major. ${detail}`);
+  }
+
+  return {
+    nodeVersion: String(majors[0]),
+    paths,
+  };
+};
+
+const detectPackageManager = dir => {
+  for (const {manager, files} of LOCKFILES) {
+    if (files.some(file => fs.existsSync(path.join(dir, file)))) {
+      return manager;
+    }
+  }
+  return null;
+};
+
+const resolveFrontendBuild = (parsed, appRoot) => {
+  if (!parsed) return null;
+  const paths = parsed.paths.map(item => {
+    const absPath = path.resolve(appRoot, item.path);
+    const manager = detectPackageManager(absPath);
+    if (!manager) {
+      throw new Error(`${item.path}: no lockfile. Commit bun.lock, bun.lockb, pnpm-lock.yaml, yarn.lock, or package-lock.json.`);
+    }
+    return {...item, manager, absPath};
+  });
+  return {
+    nodeVersion: parsed.nodeVersion,
+    paths,
+  };
+};
+
+const bootstrapCommands = plan => _(plan.paths)
+  .map(item => BOOTSTRAP[item.manager])
+  .compact()
+  .uniq()
+  .value();
+
+const pathCommands = plan => plan.paths.map(item => {
+  const workdir = path.posix.join('/app', item.path.split(path.sep).join('/'));
+  return [
+    `cd ${shQuote(workdir)}`,
+    `${item.manager} ${INSTALL_FLAGS[item.manager]}`,
+    `${item.manager} run ${shQuote(item.buildCommand)}`,
+  ].join(' && ');
+});
+
+const getBuildCommands = plan => bootstrapCommands(plan).concat(pathCommands(plan));
+
+const firstPath = plan => _.get(plan, 'paths[0].path', '.');
+
+const getPantheonFrontend = plan => {
+  const dir = `/app/${firstPath(plan)}`;
+  const tooling = {
+    'node': {service: 'frontend', cmd: 'node', dir},
+    'npm': {service: 'frontend', cmd: 'npm', dir},
+    'yarn': {service: 'frontend', cmd: 'yarn', dir},
+    'pnpm': {service: 'frontend', cmd: 'pnpm', dir},
+    'bun': {service: 'frontend', cmd: 'bun', dir},
+    'frontend-build': {
+      service: 'frontend',
+      cmd: getBuildCommands(plan).join(' && '),
+    },
+  };
+  return {
+    services: {
+      frontend: {
+        type: `pantheon-node:${plan.nodeVersion}`,
+        build: getBuildCommands(plan),
+      },
+    },
+    tooling,
+  };
+};
+
+module.exports = {
+  SUPPORTED_MAJORS,
+  DEFAULT_NODE_VERSION,
+  parseFrontendBuild,
+  detectPackageManager,
+  resolveFrontendBuild,
+  getBuildCommands,
+  getPantheonFrontend,
+};

--- a/lib/frontend-build.js
+++ b/lib/frontend-build.js
@@ -122,16 +122,13 @@ const pathCommands = plan => plan.paths.map(item => {
 
 const getBuildCommands = plan => bootstrapCommands(plan).concat(pathCommands(plan));
 
-const firstPath = plan => _.get(plan, 'paths[0].path', '.');
-
 const getPantheonFrontend = plan => {
-  const dir = `/app/${firstPath(plan)}`;
   const tooling = {
-    'node': {service: 'frontend', cmd: 'node', dir},
-    'npm': {service: 'frontend', cmd: 'npm', dir},
-    'yarn': {service: 'frontend', cmd: 'yarn', dir},
-    'pnpm': {service: 'frontend', cmd: 'pnpm', dir},
-    'bun': {service: 'frontend', cmd: 'bun', dir},
+    'node': {service: 'frontend', cmd: 'node'},
+    'npm': {service: 'frontend', cmd: 'npm'},
+    'yarn': {service: 'frontend', cmd: 'yarn'},
+    'pnpm': {service: 'frontend', cmd: 'pnpm'},
+    'bun': {service: 'frontend', cmd: 'bun'},
     'frontend-build': {
       service: 'frontend',
       cmd: getBuildCommands(plan).join(' && '),

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,6 +16,7 @@ const getPhar = require('./core-utils').getPhar;
 const PantheonApiClient = require('./client');
 const path = require('path');
 const yaml = require('js-yaml');
+const frontendBuild = require('./frontend-build');
 
 // Constants
 const DRUSH_VERSION = '8.5.0';
@@ -216,8 +217,13 @@ exports.getPantheonCache = {
  */
 exports.getPantheonConfig = (files = ['pantheon.upstream.yml', 'pantheon.yml']) => _(files)
   .filter(file => fs.existsSync(file))
-  .map(file => yaml.load(fs.readFileSync(file)))
-  .thru(data => _.merge({}, ...data))
+  .map(file => yaml.load(fs.readFileSync(file)) || {})
+  .thru(docs => {
+    const parsedFrontend = frontendBuild.parseFrontendBuild(docs);
+    const data = _.merge({}, ...docs);
+    data.frontendBuild = parsedFrontend;
+    return data;
+  })
   .thru(data => {
     // Set the php version
     data.php = _.toString(_.get(data, 'php_version', '8.3'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@lando/mariadb": "^1.7.0",
+        "@lando/node": "^1.7.0",
         "@lando/php": "^1.12.0",
         "@lando/redis": "^1.2.3",
         "@lando/solr": "^1.3.3",
@@ -1430,6 +1431,26 @@
     },
     "node_modules/@lando/mariadb/node_modules/lodash": {
       "version": "4.17.21",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@lando/node": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@lando/node/-/node-1.7.0.tgz",
+      "integrity": "sha512-/hFNKlUewysZ8yIdo8m+uUwiO0pWLsH0eZrFZS1VjZO31ZOmY/pOEsvJ/n2X7vDhyHlzvfuHMJh0DaK9ko3zeQ==",
+      "bundleDependencies": [
+        "lodash"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@lando/node/node_modules/lodash": {
+      "version": "4.17.23",
       "inBundle": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@lando/mariadb": "^1.7.0",
+    "@lando/node": "^1.7.0",
     "@lando/php": "^1.12.0",
     "@lando/redis": "^1.2.3",
     "@lando/solr": "^1.3.3",

--- a/test/frontend-build.spec.js
+++ b/test/frontend-build.spec.js
@@ -1,0 +1,212 @@
+'use strict';
+
+const chai = require('chai');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const yaml = require('js-yaml');
+const frontendBuild = require('../lib/frontend-build');
+const utils = require('../lib/utils');
+
+chai.should();
+
+describe('frontend_build', () => {
+  let tempDir;
+
+  const writeYaml = (name, content) => {
+    const file = path.join(tempDir, name);
+    fs.writeFileSync(file, content);
+    return file;
+  };
+
+  const writeLock = (relPath, lockfile) => {
+    const dir = path.join(tempDir, relPath);
+    fs.mkdirSync(dir, {recursive: true});
+    fs.writeFileSync(path.join(dir, lockfile), '');
+    return dir;
+  };
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lando-pantheon-frontend-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, {recursive: true, force: true});
+  });
+
+  describe('#parseFrontendBuild', () => {
+    it('should return null when frontend_build is absent', () => {
+      chai.expect(frontendBuild.parseFrontendBuild([{php_version: '8.3'}])).to.equal(null);
+    });
+
+    it('should default node 26 and build command build', () => {
+      const parsed = frontendBuild.parseFrontendBuild([{
+        frontend_build: {paths: [{path: 'web/themes/custom/foo'}]},
+      }]);
+
+      parsed.nodeVersion.should.equal('26');
+      parsed.paths.should.have.length(1);
+      parsed.paths[0].should.include({
+        path: 'web/themes/custom/foo',
+        nodeVersion: '26',
+        major: 26,
+        buildCommand: 'build',
+      });
+    });
+
+    it('should accept a string path entry', () => {
+      const parsed = frontendBuild.parseFrontendBuild([{
+        frontend_build: {paths: ['web/themes/custom/foo']},
+      }]);
+
+      parsed.paths[0].path.should.equal('web/themes/custom/foo');
+    });
+
+    it('should refuse unsupported node majors', () => {
+      chai.expect(() => frontendBuild.parseFrontendBuild([{
+        frontend_build: {paths: [{path: 'theme', node_version: 20}]},
+      }])).to.throw('theme: node_version 20 is not supported');
+    });
+
+    it('should refuse mixed node majors', () => {
+      chai.expect(() => frontendBuild.parseFrontendBuild([{
+        frontend_build: {
+          paths: [
+            {path: 'theme-a', node_version: 22},
+            {path: 'theme-b', node_version: 26},
+          ],
+        },
+      }])).to.throw('mixed Node majors');
+    });
+
+    it('should let later yaml win the same path and keep extra paths', () => {
+      const parsed = frontendBuild.parseFrontendBuild([
+        {
+          frontend_build: {
+            paths: [
+              {path: 'theme-a', node_version: 22, build_command: 'compile'},
+              {path: 'theme-b', node_version: 22},
+            ],
+          },
+        },
+        {
+          frontend_build: {
+            paths: [{path: 'theme-a', node_version: 22, build_command: 'build'}],
+          },
+        },
+      ]);
+
+      parsed.nodeVersion.should.equal('22');
+      parsed.paths.map(item => item.path).should.deep.equal(['theme-a', 'theme-b']);
+      parsed.paths[0].should.include({nodeVersion: '22', buildCommand: 'build'});
+    });
+  });
+
+  describe('#detectPackageManager', () => {
+    it('should prefer bun, then pnpm, yarn, npm', () => {
+      const dir = path.join(tempDir, 'theme');
+      fs.mkdirSync(dir);
+      fs.writeFileSync(path.join(dir, 'package-lock.json'), '');
+      frontendBuild.detectPackageManager(dir).should.equal('npm');
+      fs.writeFileSync(path.join(dir, 'yarn.lock'), '');
+      frontendBuild.detectPackageManager(dir).should.equal('yarn');
+      fs.writeFileSync(path.join(dir, 'pnpm-lock.yaml'), '');
+      frontendBuild.detectPackageManager(dir).should.equal('pnpm');
+      fs.writeFileSync(path.join(dir, 'bun.lock'), '');
+      frontendBuild.detectPackageManager(dir).should.equal('bun');
+    });
+
+    it('should return null when no lockfile exists', () => {
+      const dir = path.join(tempDir, 'empty');
+      fs.mkdirSync(dir);
+      chai.expect(frontendBuild.detectPackageManager(dir)).to.equal(null);
+    });
+  });
+
+  describe('#resolveFrontendBuild', () => {
+    it('should attach the lockfile package manager', () => {
+      writeLock('web/themes/custom/foo', 'pnpm-lock.yaml');
+      const parsed = frontendBuild.parseFrontendBuild([{
+        frontend_build: {paths: [{path: 'web/themes/custom/foo'}]},
+      }]);
+
+      const plan = frontendBuild.resolveFrontendBuild(parsed, tempDir);
+      plan.paths[0].manager.should.equal('pnpm');
+    });
+
+    it('should name the path when a lockfile is missing', () => {
+      fs.mkdirSync(path.join(tempDir, 'web/themes/custom/foo'), {recursive: true});
+      const parsed = frontendBuild.parseFrontendBuild([{
+        frontend_build: {paths: [{path: 'web/themes/custom/foo'}]},
+      }]);
+
+      chai.expect(() => frontendBuild.resolveFrontendBuild(parsed, tempDir))
+        .to.throw('web/themes/custom/foo: no lockfile');
+    });
+  });
+
+  describe('#getBuildCommands', () => {
+    it('should install missing package managers and build each path', () => {
+      writeLock('theme-a', 'yarn.lock');
+      writeLock('theme-b', 'package-lock.json');
+      const parsed = frontendBuild.parseFrontendBuild([{
+        frontend_build: {
+          paths: [
+            {path: 'theme-a', build_command: 'build'},
+            {path: 'theme-b', build_command: 'compile'},
+          ],
+        },
+      }]);
+      const plan = frontendBuild.resolveFrontendBuild(parsed, tempDir);
+      const commands = frontendBuild.getBuildCommands(plan);
+
+      commands[0].should.include('npm install --global yarn');
+      commands[1].should.include('/app/theme-a');
+      commands[1].should.include('yarn install --frozen-lockfile');
+      commands[1].should.include('yarn run');
+      commands[1].should.include('build');
+      commands[2].should.include('/app/theme-b');
+      commands[2].should.include('npm ci');
+      commands[2].should.include('npm run');
+      commands[2].should.include('compile');
+    });
+  });
+
+  describe('#getPantheonFrontend', () => {
+    it('should add a node sidecar and daily tooling', () => {
+      writeLock('web/themes/custom/foo', 'pnpm-lock.yaml');
+      const parsed = frontendBuild.parseFrontendBuild([{
+        frontend_build: {paths: [{path: 'web/themes/custom/foo'}]},
+      }]);
+      const extra = frontendBuild.getPantheonFrontend(
+        frontendBuild.resolveFrontendBuild(parsed, tempDir),
+      );
+
+      extra.services.frontend.type.should.equal('pantheon-node:26');
+      extra.tooling.pnpm.service.should.equal('frontend');
+      extra.tooling.pnpm.dir.should.equal('/app/web/themes/custom/foo');
+      extra.tooling['frontend-build'].cmd.should.include('pnpm run');
+    });
+  });
+
+  describe('#getPantheonConfig', () => {
+    it('should parse frontend_build from pantheon.yml', () => {
+      const file = writeYaml('pantheon.yml', yaml.dump({
+        php_version: '8.3',
+        frontend_build: {
+          paths: [{path: 'web/themes/custom/foo', node_version: 24}],
+        },
+      }));
+
+      const config = utils.getPantheonConfig([file]);
+      config.frontendBuild.nodeVersion.should.equal('24');
+      config.frontendBuild.paths[0].path.should.equal('web/themes/custom/foo');
+    });
+
+    it('should leave frontendBuild null when unset', () => {
+      const file = writeYaml('pantheon.yml', 'php_version: 8.3\n');
+      const config = utils.getPantheonConfig([file]);
+      chai.expect(config.frontendBuild).to.equal(null);
+    });
+  });
+});

--- a/test/frontend-build.spec.js
+++ b/test/frontend-build.spec.js
@@ -184,7 +184,7 @@ describe('frontend_build', () => {
 
       extra.services.frontend.type.should.equal('pantheon-node:26');
       extra.tooling.pnpm.service.should.equal('frontend');
-      extra.tooling.pnpm.dir.should.equal('/app/web/themes/custom/foo');
+      chai.expect(extra.tooling.pnpm.dir).to.equal(undefined);
       extra.tooling['frontend-build'].cmd.should.include('pnpm run');
     });
   });

--- a/test/frontend-build.spec.js
+++ b/test/frontend-build.spec.js
@@ -184,7 +184,9 @@ describe('frontend_build', () => {
 
       extra.services.frontend.type.should.equal('pantheon-node:26');
       extra.tooling.pnpm.service.should.equal('frontend');
-      chai.expect(extra.tooling.pnpm.dir).to.equal(undefined);
+      chai.expect(extra.tooling.npm).to.equal(undefined);
+      chai.expect(extra.tooling.yarn).to.equal(undefined);
+      chai.expect(extra.tooling.bun).to.equal(undefined);
       extra.tooling['frontend-build'].cmd.should.include('pnpm run');
     });
   });


### PR DESCRIPTION
## Summary

If a site has Pantheon `frontend_build` in `pantheon.yml` / `pantheon.upstream.yml`, Lando now builds those paths locally. No extra Node block in the Landofile.

This is the theme-dev workflow, not a CI clone:

- Invisible `frontend` sidecar via `@lando/node` (`pantheon-node`). Shares `/app`. Does not install Node on the PHP appserver.
- Node 22 / 24 / 26, default **26**. Mixed majors across paths are refused with the path names.
- Lockfile order matches Pantheon: bun → pnpm → yarn → npm. Missing lockfile fails that path by name.
- Start/rebuild runs install + `<pm> run <build_command>` for each path. `pnpm` / `bun` / `yarn` are installed on the sidecar when the lockfile needs them.
- Daily tooling: `lando npm`, `lando yarn`, `lando pnpm`, `lando bun`, `lando node` (cwd = first path) and `lando frontend-build` to rerun everything.

## Test plan

- [x] `npm test` (lint + unit) — 21 passing
- [ ] `lando start` on a Drupal/WordPress app with `frontend_build` and a real lockfile
- [ ] `lando npm run watch` from a single-path theme
- [ ] Confirm a missing lockfile error names the path
- [ ] Confirm mixed Node majors are refused

## Notes

Published `@lando/node@1.7.0` is now a dependency. The wrapper also keeps 22/24/26 in the supported list so a slightly older nested install still accepts those majors.