### PR TITLE
test: cover PHP 8.5 on the Drupal 11 example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ lib/        # Core library code (auth, client, utils)
 scripts/    # Shell scripts for containers
 test/       # Unit tests (*.spec.js)
 utils/      # Utility modules
+examples/   # Leia fixtures. See examples/AGENTS.md — remote landobot sites use master, not main.
 ```
 
 ## Code Style Guidelines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Added support for Pantheon `frontend_build`
 * Updated PHP `8.2`, `8.3`, `8.4`, and `8.5` images to Terminus `4.3.2` [#360](https://github.com/lando/pantheon/issues/360)
 * Fixed `manifest unknown` Docker error by validating `php_version` and `php_runtime_generation` against published images and falling back to a working generation when needed [#347](https://github.com/lando/pantheon/issues/347)
+* Added PHP `8.5` coverage to the Drupal 11 Leia example [#352](https://github.com/lando/pantheon/issues/352)
 
 ## v1.14.0 - [June 4, 2026](https://github.com/lando/pantheon/releases/tag/v1.14.0)
 

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -6,6 +6,7 @@ Pantheon example sites that clone a remote (`landobot-*` via `lando init --sourc
 - Do not `git clone` the default branch and assume it is current. `main` can exist and be stale or empty of site config.
 - Change remote site code the same way the example READMEs do: `lando init` → edit → `lando push --code dev`. That checks out `master` and pushes it.
 - After applying code/dependency updates on a remote Drupal example: `lando drush updb -y`, then `lando drush cex -y`, then `lando push --code dev`. Do not skip the config export.
+- When teardown is done, `lando destroy -y` the local app. Do not leave a landobot example running.
 - Never run `lando init` inside the example directory itself. Init into a nested work dir (as the READMEs do) so the cloned site does not overwrite the example.
 
 Local-only examples (`frontend-build`, `pantheon-php-warning`, downstreamers) have no Pantheon remote and do not use this branch rule.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -5,6 +5,7 @@ Pantheon example sites that clone a remote (`landobot-*` via `lando init --sourc
 - Inspect or change those remotes on `master`.
 - Do not `git clone` the default branch and assume it is current. `main` can exist and be stale or empty of site config.
 - Change remote site code the same way the example READMEs do: `lando init` → edit → `lando push --code dev`. That checks out `master` and pushes it.
+- After applying code/dependency updates on a remote Drupal example: `lando drush updb -y`, then `lando drush cex -y`, then `lando push --code dev`. Do not skip the config export.
 - Never run `lando init` inside the example directory itself. Init into a nested work dir (as the READMEs do) so the cloned site does not overwrite the example.
 
 Local-only examples (`frontend-build`, `pantheon-php-warning`, downstreamers) have no Pantheon remote and do not use this branch rule.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -1,0 +1,10 @@
+# Examples
+
+Pantheon example sites that clone a remote (`landobot-*` via `lando init --source pantheon`) use **`master`**, not `main`.
+
+- Inspect or change those remotes on `master`.
+- Do not `git clone` the default branch and assume it is current. `main` can exist and be stale or empty of site config.
+- Change remote site code the same way the example READMEs do: `lando init` → edit → `lando push --code dev`. That checks out `master` and pushes it.
+- Never run `lando init` inside the example directory itself. Init into a nested work dir (as the READMEs do) so the cloned site does not overwrite the example.
+
+Local-only examples (`frontend-build`, `pantheon-php-warning`, downstreamers) have no Pantheon remote and do not use this branch rule.

--- a/examples/drupal11/README.md
+++ b/examples/drupal11/README.md
@@ -1,184 +1,22 @@
-# Pantheon Drupal 11 Example
+# Composer-enabled Drupal template
 
-This example exists primarily to test the following:
+This is Pantheon's recommended starting point for forking new [Drupal](https://www.drupal.org/) upstreams
+that work with the Platform's Integrated Composer build process. It is also the
+Platform's standard Drupal 9 upstream.
 
-* [Pantheon Recipe - Drupal 11](https://docs.lando.dev/plugins/pantheon)
+Unlike with earlier Pantheon upstreams, files such as Drupal Core that you are
+unlikely to adjust while building sites are not in the main branch of the 
+repository. Instead, they are referenced as dependencies that are installed by
+Composer.
 
-**Note that you will need to replace (or export) `$PANTHEON_MACHINE_TOKEN` and `--pantheon-site` to values that make sense for you.**
+For more information and detailed installation guides, please visit the
+Integrated Composer Pantheon documentation: https://pantheon.io/docs/integrated-composer
 
-## Start up tests
+## Contributing
 
-Run the following commands to get up and running with this example.
+Contributions are welcome in the form of GitHub pull requests. However, the
+`pantheon-upstreams/drupal-composer-managed` repository is a mirror that does not
+directly accept pull requests.
 
-```bash
-# Should poweroff
-lando poweroff
-
-# Should initialize the lando pantheon test drupal11 site
-rm -rf drupal11 && mkdir -p drupal11 && cd drupal11
-lando init --source pantheon --pantheon-auth "$PANTHEON_MACHINE_TOKEN" --pantheon-site landobot-drupal11
-cp ../../.lando.upstream.yml .lando.upstream.yml
-# Pin PHP 8.5 locally so this example covers the 8.5-5 image even if the
-# remote landobot-drupal11 pantheon.yml is still on an older version.
-sed -i 's/^php_version:.*/php_version: 8.5/' pantheon.yml
-
-# Should start up our drupal11 site successfully
-cd drupal11
-lando start
-
-# Should pull down database and files for our drupal11 site
-cd drupal11
-lando pull --code none --database dev --files dev --rsync
-```
-
-## Verification commands
-
-Run the following commands to validate things are rolling as they should.
-
-```bash
-# Should be able to bootstrap drupal11
-cd drupal11
-lando drush status | grep "Connected"
-
-# Should use the drush in pantheon.yml
-cd drupal11
-lando drush version | grep 13.
-
-# Should have terminus
-cd drupal11
-lando terminus -V
-
-# Should be logged in
-cd drupal11
-lando terminus auth:whoami | grep "@"
-
-# Should have a binding.pem in all the right places
-cd drupal11
-lando exec appserver -- "stat /var/www/certs/binding.pem"
-lando exec appserver -u root -- "stat /root/certs/binding.pem"
-
-# Should set the correct pantheon environment
-cd drupal11
-lando exec appserver -- "env" | grep BACKDROP_SETTINGS | grep pantheon
-lando exec appserver -- "env" | grep CACHE_HOST | grep cache
-lando exec appserver -- "env" | grep CACHE_PORT | grep 6379
-lando exec appserver -- "env" | grep DB_HOST | grep database
-lando exec appserver -- "env" | grep DB_PORT | grep 3306
-lando exec appserver -- "env" | grep DB_USER | grep pantheon
-lando exec appserver -- "env" | grep DB_PASSWORD | grep pantheon
-lando exec appserver -- "env" | grep DB_NAME | grep pantheon
-lando exec appserver -- "env" | grep FRAMEWORK | grep drupal8
-lando exec appserver -- "env" | grep FILEMOUNT | grep "sites/default/files"
-lando exec appserver -- "env" | grep PANTHEON_ENVIRONMENT | grep lando
-lando exec appserver -- "env" | grep -x "PANTHEON_INDEX_CORE=lando"
-lando exec appserver -- "env" | grep -x "PANTHEON_INDEX_PATH="
-lando exec appserver -- "env" | grep PANTHEON_INDEX_HOST | grep index
-lando exec appserver -- "env" | grep PANTHEON_INDEX_PORT | grep 8983
-lando exec appserver -- "env" | grep PANTHEON_INDEX_SCHEMA | grep "solr\/#\/lando\/schema"
-lando exec appserver -- "env" | grep PANTHEON_INDEX_SCHEME | grep http
-lando exec appserver -- "env" | grep PANTHEON_SITE | grep c354aed8-76eb-44d7-8f54-57b9ea3079be
-lando exec appserver -- "env" | grep PANTHEON_SITE_NAME | grep landobot-drupal11
-lando exec appserver -- "env" | grep php_version | grep "8.5"
-lando exec appserver -- "env" | grep PRESSFLOW_SETTINGS | grep pantheon
-lando exec appserver -- "env" | grep TERMINUS_ENV | grep dev
-lando exec appserver -- "env" | grep TERMINUS_SITE | grep landobot-drupal11
-lando exec appserver -- "env" | grep -E "TERMINUS_USER=.+@.+"
-
-# Should use php 8.5 in pantheon.yml
-cd drupal11
-lando php -v | grep "PHP 8.5"
-
-# Should use the database version in pantheon.yml
-cd drupal11
-lando exec database -- "mysql -V" | grep 10.6.
-
-# Should use the solr version in pantheon.yml
-cd drupal11
-lando exec appserver -- "curl http://index:8983/solr/admin/info/system" | grep "\"solr-spec-version\":\"9.10.1\""
-
-# Jetty redirects should work for Pantheon Search
-cd drupal11
-lando exec appserver -- "curl http://index:8983/lando/v1/lando/admin/system" | grep "\"solr-spec-version\":\"9.10.1\""
-
-# The Solr connector env vars should resolve to the core
-cd drupal11
-lando exec appserver -- "curl http://\$PANTHEON_INDEX_HOST:\$PANTHEON_INDEX_PORT/\$PANTHEON_INDEX_PATH\$PANTHEON_INDEX_CORE/admin/system" | grep "\"solr-spec-version\":\"9.10.1\""
-
-# Should have the transaction isolation level set to READ-COMMITTED
-cd drupal11
-lando mysql -e "SELECT @@tx_isolation;" | grep READ-COMMITTED
-
-# Should use a varnish http_resp_hdr_len setting of 25k
-cd drupal11
-lando varnishadm param.show http_resp_hdr_len | grep 'Value is: 25k'
-
-# Should have all pantheon services running and their tooling enabled by defaults
-docker ps --filter label=com.docker.compose.project=landobotdrupal11 | grep landobotdrupal11_appserver_nginx_1
-docker ps --filter label=com.docker.compose.project=landobotdrupal11 | grep landobotdrupal11_appserver_1
-docker ps --filter label=com.docker.compose.project=landobotdrupal11 | grep landobotdrupal11_database_1
-
-# Should use the correct default config files
-cd drupal11
-lando exec appserver -- "cat /usr/local/etc/php/conf.d/zzz-lando-my-custom.ini" | grep "; LANDOPANTHEONPHPINI"
-lando exec database -- "cat /opt/bitnami/mariadb/conf/my_custom.cnf" | grep "LANDOPANTHEONMYSQLCNF"
-
-# Should not have xdebug enabled by default
-cd drupal11
-lando php -m | grep xdebug || echo $? | grep 1
-
-# Should have the imagick PHP extension enabled
-cd drupal11
-lando php -m | grep imagick
-
-# Should have ImageMagick 7 for PHP 8.5
-cd drupal11
-lando php -r 'echo Imagick::getVersion()["versionString"];' | grep "ImageMagick 7\."
-
-# Should have phpredis with igbinary support
-cd drupal11
-lando php -r 'var_dump(defined("Redis::SERIALIZER_IGBINARY"));' | grep 'bool(true)'
-
-# Should be able to pull the database without SSL errors
-# https://github.com/lando/pantheon/issues/316
-cd drupal11
-! lando pull --code none --database dev --files none 2>&1 | grep "TLS/SSL error"
-
-# Should be able to connect to the database with mysql client without SSL errors
-cd drupal11
-lando exec appserver -- "mysql -h database -u pantheon -ppantheon pantheon -e 'SELECT 1'" | grep 1
-
-# Should be able to push commits to pantheon
-cd drupal11
-lando pull --code dev --database none --files none
-lando exec appserver -- "git pull --rebase"
-lando exec appserver -- "git rev-parse HEAD > test.log"
-lando push --code dev --database none --files none --message "Testing commit $(git rev-parse HEAD)"
-
-# Should allow code pull from protected environments
-# https://github.com/lando/lando/issues/2021
-cd drupal11
-lando pull --code test --database none --files none
-lando pull --code live --database none --files none
-
-# Should switch to multidev environment
-cd drupal11
-lando switch -e tester
-```
-
-## Destroy tests
-
-Run the following commands to trash this app like nothing ever happened.
-
-```bash
-# Should be able to remove our pantheon ssh keys
-cp -r remove-keys.sh drupal11/remove-keys.sh
-cd drupal11
-lando exec appserver -- "/app/remove-keys.sh"
-cd ..
-rm -rf drupal11/remove-keys.sh
-
-# Should be able to destroy our drupal11 site with success
-cd drupal11
-lando destroy -y
-lando poweroff
-```
+Instead, to propose a change, please fork [pantheon-systems/drupal-composer-managed](https://github.com/pantheon-systems/drupal-composer-managed)
+and submit a PR to that repository.

--- a/examples/drupal11/README.md
+++ b/examples/drupal11/README.md
@@ -18,6 +18,9 @@ lando poweroff
 rm -rf drupal11 && mkdir -p drupal11 && cd drupal11
 lando init --source pantheon --pantheon-auth "$PANTHEON_MACHINE_TOKEN" --pantheon-site landobot-drupal11
 cp ../../.lando.upstream.yml .lando.upstream.yml
+# Pin PHP 8.5 locally so this example covers the 8.5-5 image even if the
+# remote landobot-drupal11 pantheon.yml is still on an older version.
+sed -i 's/^php_version:.*/php_version: 8.5/' pantheon.yml
 
 # Should start up our drupal11 site successfully
 cd drupal11
@@ -75,15 +78,15 @@ lando exec appserver -- "env" | grep PANTHEON_INDEX_SCHEMA | grep "solr\/#\/land
 lando exec appserver -- "env" | grep PANTHEON_INDEX_SCHEME | grep http
 lando exec appserver -- "env" | grep PANTHEON_SITE | grep c354aed8-76eb-44d7-8f54-57b9ea3079be
 lando exec appserver -- "env" | grep PANTHEON_SITE_NAME | grep landobot-drupal11
-lando exec appserver -- "env" | grep php_version | grep "8.4"
+lando exec appserver -- "env" | grep php_version | grep "8.5"
 lando exec appserver -- "env" | grep PRESSFLOW_SETTINGS | grep pantheon
 lando exec appserver -- "env" | grep TERMINUS_ENV | grep dev
 lando exec appserver -- "env" | grep TERMINUS_SITE | grep landobot-drupal11
 lando exec appserver -- "env" | grep -E "TERMINUS_USER=.+@.+"
 
-# Should use php 8.4 in pantheon.yml
+# Should use php 8.5 in pantheon.yml
 cd drupal11
-lando php -v | grep "PHP 8.4"
+lando php -v | grep "PHP 8.5"
 
 # Should use the database version in pantheon.yml
 cd drupal11
@@ -127,7 +130,7 @@ lando php -m | grep xdebug || echo $? | grep 1
 cd drupal11
 lando php -m | grep imagick
 
-# Should have ImageMagick 7 for PHP 8.4
+# Should have ImageMagick 7 for PHP 8.5
 cd drupal11
 lando php -r 'echo Imagick::getVersion()["versionString"];' | grep "ImageMagick 7\."
 

--- a/examples/drupal11/README.md
+++ b/examples/drupal11/README.md
@@ -1,22 +1,181 @@
-# Composer-enabled Drupal template
+# Pantheon Drupal 11 Example
 
-This is Pantheon's recommended starting point for forking new [Drupal](https://www.drupal.org/) upstreams
-that work with the Platform's Integrated Composer build process. It is also the
-Platform's standard Drupal 9 upstream.
+This example exists primarily to test the following:
 
-Unlike with earlier Pantheon upstreams, files such as Drupal Core that you are
-unlikely to adjust while building sites are not in the main branch of the 
-repository. Instead, they are referenced as dependencies that are installed by
-Composer.
+* [Pantheon Recipe - Drupal 11](https://docs.lando.dev/plugins/pantheon)
 
-For more information and detailed installation guides, please visit the
-Integrated Composer Pantheon documentation: https://pantheon.io/docs/integrated-composer
+**Note that you will need to replace (or export) `$PANTHEON_MACHINE_TOKEN` and `--pantheon-site` to values that make sense for you.**
 
-## Contributing
+## Start up tests
 
-Contributions are welcome in the form of GitHub pull requests. However, the
-`pantheon-upstreams/drupal-composer-managed` repository is a mirror that does not
-directly accept pull requests.
+Run the following commands to get up and running with this example.
 
-Instead, to propose a change, please fork [pantheon-systems/drupal-composer-managed](https://github.com/pantheon-systems/drupal-composer-managed)
-and submit a PR to that repository.
+```bash
+# Should poweroff
+lando poweroff
+
+# Should initialize the lando pantheon test drupal11 site
+rm -rf drupal11 && mkdir -p drupal11 && cd drupal11
+lando init --source pantheon --pantheon-auth "$PANTHEON_MACHINE_TOKEN" --pantheon-site landobot-drupal11
+cp ../../.lando.upstream.yml .lando.upstream.yml
+
+# Should start up our drupal11 site successfully
+cd drupal11
+lando start
+
+# Should pull down database and files for our drupal11 site
+cd drupal11
+lando pull --code none --database dev --files dev --rsync
+```
+
+## Verification commands
+
+Run the following commands to validate things are rolling as they should.
+
+```bash
+# Should be able to bootstrap drupal11
+cd drupal11
+lando drush status | grep "Connected"
+
+# Should use the drush in pantheon.yml
+cd drupal11
+lando drush version | grep 13.
+
+# Should have terminus
+cd drupal11
+lando terminus -V
+
+# Should be logged in
+cd drupal11
+lando terminus auth:whoami | grep "@"
+
+# Should have a binding.pem in all the right places
+cd drupal11
+lando exec appserver -- "stat /var/www/certs/binding.pem"
+lando exec appserver -u root -- "stat /root/certs/binding.pem"
+
+# Should set the correct pantheon environment
+cd drupal11
+lando exec appserver -- "env" | grep BACKDROP_SETTINGS | grep pantheon
+lando exec appserver -- "env" | grep CACHE_HOST | grep cache
+lando exec appserver -- "env" | grep CACHE_PORT | grep 6379
+lando exec appserver -- "env" | grep DB_HOST | grep database
+lando exec appserver -- "env" | grep DB_PORT | grep 3306
+lando exec appserver -- "env" | grep DB_USER | grep pantheon
+lando exec appserver -- "env" | grep DB_PASSWORD | grep pantheon
+lando exec appserver -- "env" | grep DB_NAME | grep pantheon
+lando exec appserver -- "env" | grep FRAMEWORK | grep drupal8
+lando exec appserver -- "env" | grep FILEMOUNT | grep "sites/default/files"
+lando exec appserver -- "env" | grep PANTHEON_ENVIRONMENT | grep lando
+lando exec appserver -- "env" | grep -x "PANTHEON_INDEX_CORE=lando"
+lando exec appserver -- "env" | grep -x "PANTHEON_INDEX_PATH="
+lando exec appserver -- "env" | grep PANTHEON_INDEX_HOST | grep index
+lando exec appserver -- "env" | grep PANTHEON_INDEX_PORT | grep 8983
+lando exec appserver -- "env" | grep PANTHEON_INDEX_SCHEMA | grep "solr\/#\/lando\/schema"
+lando exec appserver -- "env" | grep PANTHEON_INDEX_SCHEME | grep http
+lando exec appserver -- "env" | grep PANTHEON_SITE | grep c354aed8-76eb-44d7-8f54-57b9ea3079be
+lando exec appserver -- "env" | grep PANTHEON_SITE_NAME | grep landobot-drupal11
+lando exec appserver -- "env" | grep php_version | grep "8.5"
+lando exec appserver -- "env" | grep PRESSFLOW_SETTINGS | grep pantheon
+lando exec appserver -- "env" | grep TERMINUS_ENV | grep dev
+lando exec appserver -- "env" | grep TERMINUS_SITE | grep landobot-drupal11
+lando exec appserver -- "env" | grep -E "TERMINUS_USER=.+@.+"
+
+# Should use php 8.5 in pantheon.yml
+cd drupal11
+lando php -v | grep "PHP 8.5"
+
+# Should use the database version in pantheon.yml
+cd drupal11
+lando exec database -- "mysql -V" | grep 10.6.
+
+# Should use the solr version in pantheon.yml
+cd drupal11
+lando exec appserver -- "curl http://index:8983/solr/admin/info/system" | grep "\"solr-spec-version\":\"9.10.1\""
+
+# Jetty redirects should work for Pantheon Search
+cd drupal11
+lando exec appserver -- "curl http://index:8983/lando/v1/lando/admin/system" | grep "\"solr-spec-version\":\"9.10.1\""
+
+# The Solr connector env vars should resolve to the core
+cd drupal11
+lando exec appserver -- "curl http://\$PANTHEON_INDEX_HOST:\$PANTHEON_INDEX_PORT/\$PANTHEON_INDEX_PATH\$PANTHEON_INDEX_CORE/admin/system" | grep "\"solr-spec-version\":\"9.10.1\""
+
+# Should have the transaction isolation level set to READ-COMMITTED
+cd drupal11
+lando mysql -e "SELECT @@tx_isolation;" | grep READ-COMMITTED
+
+# Should use a varnish http_resp_hdr_len setting of 25k
+cd drupal11
+lando varnishadm param.show http_resp_hdr_len | grep 'Value is: 25k'
+
+# Should have all pantheon services running and their tooling enabled by defaults
+docker ps --filter label=com.docker.compose.project=landobotdrupal11 | grep landobotdrupal11_appserver_nginx_1
+docker ps --filter label=com.docker.compose.project=landobotdrupal11 | grep landobotdrupal11_appserver_1
+docker ps --filter label=com.docker.compose.project=landobotdrupal11 | grep landobotdrupal11_database_1
+
+# Should use the correct default config files
+cd drupal11
+lando exec appserver -- "cat /usr/local/etc/php/conf.d/zzz-lando-my-custom.ini" | grep "; LANDOPANTHEONPHPINI"
+lando exec database -- "cat /opt/bitnami/mariadb/conf/my_custom.cnf" | grep "LANDOPANTHEONMYSQLCNF"
+
+# Should not have xdebug enabled by default
+cd drupal11
+lando php -m | grep xdebug || echo $? | grep 1
+
+# Should have the imagick PHP extension enabled
+cd drupal11
+lando php -m | grep imagick
+
+# Should have ImageMagick 7 for PHP 8.5
+cd drupal11
+lando php -r 'echo Imagick::getVersion()["versionString"];' | grep "ImageMagick 7\."
+
+# Should have phpredis with igbinary support
+cd drupal11
+lando php -r 'var_dump(defined("Redis::SERIALIZER_IGBINARY"));' | grep 'bool(true)'
+
+# Should be able to pull the database without SSL errors
+# https://github.com/lando/pantheon/issues/316
+cd drupal11
+! lando pull --code none --database dev --files none 2>&1 | grep "TLS/SSL error"
+
+# Should be able to connect to the database with mysql client without SSL errors
+cd drupal11
+lando exec appserver -- "mysql -h database -u pantheon -ppantheon pantheon -e 'SELECT 1'" | grep 1
+
+# Should be able to push commits to pantheon
+cd drupal11
+lando pull --code dev --database none --files none
+lando exec appserver -- "git pull --rebase"
+lando exec appserver -- "git rev-parse HEAD > test.log"
+lando push --code dev --database none --files none --message "Testing commit $(git rev-parse HEAD)"
+
+# Should allow code pull from protected environments
+# https://github.com/lando/lando/issues/2021
+cd drupal11
+lando pull --code test --database none --files none
+lando pull --code live --database none --files none
+
+# Should switch to multidev environment
+cd drupal11
+lando switch -e tester
+```
+
+## Destroy tests
+
+Run the following commands to trash this app like nothing ever happened.
+
+```bash
+# Should be able to remove our pantheon ssh keys
+cp -r remove-keys.sh drupal11/remove-keys.sh
+cd drupal11
+lando exec appserver -- "/app/remove-keys.sh"
+cd ..
+rm -rf drupal11/remove-keys.sh
+
+# Should be able to destroy our drupal11 site with success
+cd drupal11
+lando destroy -y
+lando poweroff
+```


### PR DESCRIPTION
## Summary

Fixes #352.

The Drupal 11 Leia example now exercises `php_version: 8.5` after `lando init`, so CI covers the `8.5-5` image, ImageMagick 7, Terminus, and Redis igbinary on the normal recipe path.

The remote `landobot-drupal11` `pantheon.yml` is pinned locally after init so this does not depend on that site already being 8.5.

## Test plan

- [x] Drupal 11 example asserts `php_version` 8.5 and `PHP 8.5`
- [ ] CI Leia `examples/drupal11` on 3-stable / 3-edge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and Leia assertion updates only; no changes to builders, runtime, or auth.
> 
> **Overview**
> **Drupal 11 Leia coverage** now expects **`php_version` 8.5**, **`PHP 8.5`**, and ImageMagick 7 for 8.5 in `examples/drupal11/README.md` (replacing 8.4), so CI exercises the PHP 8.5 image path on the normal recipe.
> 
> **Contributor docs:** root `AGENTS.md` lists `examples/` and points to new **`examples/AGENTS.md`**, which documents that Pantheon `landobot-*` fixtures use **`master`** (not `main`) and the init → edit → `lando push --code dev` / Drush update workflow.
> 
> **CHANGELOG** records PHP 8.5 coverage for the Drupal 11 Leia example ([#352](https://github.com/lando/pantheon/issues/352)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 539c4139007c57f396f17022af1d8658c8bfa830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->